### PR TITLE
requirements: Pin "werkzeug" package to v0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask==0.9
+werkzeug==0.8.3
 Flask-Babel==0.8
 Flask-Assets==0.8
 Flask-Login==0.1.3


### PR DESCRIPTION
The current stable version 0.9 is incompatible with flask 0.9

This should fix the tests on TravisCI
