### PR TITLE
model.flight_phase: Use Float instead of Numeric

### DIFF
--- a/assets/SQL/52-numeric-to-float.sql
+++ b/assets/SQL/52-numeric-to-float.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE flight_phases
+   ALTER COLUMN speed TYPE real;
+ALTER TABLE flight_phases
+   ALTER COLUMN vario TYPE real;
+ALTER TABLE flight_phases
+   ALTER COLUMN glide_rate TYPE real;
+
+COMMIT;

--- a/skylines/model/flight_phase.py
+++ b/skylines/model/flight_phase.py
@@ -1,4 +1,4 @@
-from sqlalchemy.types import Boolean, Numeric, Integer, DateTime, Interval
+from sqlalchemy.types import Boolean, Float, Integer, DateTime, Interval
 
 from skylines import db
 
@@ -35,7 +35,7 @@ class FlightPhase(db.Model):
     duration = db.Column(Interval)
     fraction = db.Column(Integer)
     distance = db.Column(Integer)
-    speed = db.Column(Numeric)
-    vario = db.Column(Numeric)
-    glide_rate = db.Column(Numeric)
+    speed = db.Column(Float)
+    vario = db.Column(Float)
+    glide_rate = db.Column(Float)
     count = db.Column(Integer, nullable=False)


### PR DESCRIPTION
Numeric has far worse performance characteristics and the table size
decreases from 95 MB to 87 MB after this patch.

as @TobiasLohner pointed out in https://github.com/skylines-project/skylines/pull/90#issuecomment-19497824
