### PR TITLE
Fixes initialise_database file mention to match the actual filename

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ versions of PostgreSQL, PostGIS and other operating systems. See the
 appropriate documentation and websites for more information.*
 
 After creating the database you have to create the necessary tables and indices
-by calling the `./scripts/initialize_database.py` file from the the command
+by calling the `./scripts/initialise_database.py` file from the the command
 line.
 
 


### PR DESCRIPTION
The INSTALL.md mentions calling the 'scripts/initialize_database.py' file while installing Skylines. The actual file is called 'initialise_database'. The INSTALL.md has been changed to reflect this discrepancy.
