### PR TITLE
forms: Removed club field from registration form

### DIFF
--- a/skylines/forms/pilot.py
+++ b/skylines/forms/pilot.py
@@ -15,7 +15,6 @@ from skylines.forms.units import (
     UnitsPresetSelectField, DistanceUnitSelectField, AltitudeUnitSelectField,
     LiftUnitSelectField, SpeedUnitSelectField
 )
-from skylines.forms.club import ClubsSelectField
 
 
 class ClubPilotsSelectField(SelectField):
@@ -60,7 +59,7 @@ class CreateClubPilotForm(Form):
 class CreatePilotForm(CreateClubPilotForm, ChangePasswordForm):
     # email_address, name from CreateClubPilotForm
     # password, verify_password from ChangePasswordForm
-    club_id = ClubsSelectField(l_('Club'))
+    pass
 
 
 class TrackingDelaySelectField(SelectField):

--- a/skylines/templates/users/new.jinja
+++ b/skylines/templates/users/new.jinja
@@ -10,7 +10,6 @@
   {{ form.hidden_tag() }}
   {{ render_field(form.email_address) }}
   {{ render_two_fields(_('First and last name'), form.first_name, form.last_name) }}
-  {{ render_field(form.club_id) }}
   {{ render_field(form.password) }}
   {{ render_field(form.verify_password) }}
   <div class="form-group">

--- a/skylines/views/users.py
+++ b/skylines/views/users.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import joinedload
 
 from skylines import db
 from skylines.model import User
-from skylines.model.event import create_new_user_event, create_club_join_event
+from skylines.model.event import create_new_user_event
 from skylines.forms import CreatePilotForm, RecoverStep1Form, RecoverStep2Form
 
 users_blueprint = Blueprint('users', 'skylines')
@@ -45,16 +45,11 @@ def new_post(form):
         password=form.password.data
     )
 
-    if form.club_id.data:
-        user.club_id = form.club_id.data
-
     user.created_ip = request.remote_addr
     user.generate_tracking_key()
     db.session.add(user)
 
     create_new_user_event(user)
-    if user.club_id:
-        create_club_join_event(user.club_id, user)
 
     db.session.commit()
 


### PR DESCRIPTION
This caused much confusion because people didn't know how to add their
own club to the list upon registration so they didn't register. Now we let
them register without a club and discover the proper club change form
later.
