### PR TITLE
TravisCI: Use ppa:ubuntugis/ppa instead of ppa:sharpie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ services:
 
 install:
   # Add PPAs for GEOS 3.3.x and PostGIS 2.x
-  - sudo apt-add-repository -y ppa:sharpie/for-science
-  - sudo apt-add-repository -y ppa:sharpie/postgis-nightly
+  - sudo apt-add-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update
 
   # Install PostGIS
@@ -28,7 +27,7 @@ before_script:
 
   # Install PostGIS extension into the database
   - psql -U postgres -d skylines_test -c 'CREATE EXTENSION postgis;'
-  - psql -U postgres -d skylines_test -f /usr/share/postgresql/9.1/contrib/postgis-2.1/legacy_minimal.sql
+  - psql -U postgres -d skylines_test -f /usr/share/postgresql/9.1/contrib/postgis-2.0/legacy_minimal.sql
 
   # Install fuzzystrmatch extension into the database
   - psql -U postgres -d skylines_test -c 'CREATE EXTENSION fuzzystrmatch;'


### PR DESCRIPTION
This fixes the TravisCI build failures from earlier today. Apparently the ppa:sharpie does not work so well anymore and since we don't require PostGIS 2.1 we might as well use 2.0 from the ubuntugis repository.
