### PR TITLE
forms.select: remove GroupSelectWidget

### DIFF
--- a/skylines/frontend/forms/select.py
+++ b/skylines/frontend/forms/select.py
@@ -4,7 +4,7 @@ from wtforms.widgets import Select
 from wtforms.widgets.core import HTMLString, html_params, escape
 
 
-__all__ = ('GroupSelectField', 'GroupSelectWidget')
+__all__ = ('GroupSelectField')
 
 
 class GroupSelect(Select):


### PR DESCRIPTION
Which is not a valid name. Fixes pyflakes 0.8 errors
