### PR TITLE
Spelling changes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ by calling `./manage.py db create` from the the command line.
 Since the [XCSoar](http://www.xcsoar.org/) project already has much of the code
 implemented that is necessary for flight analysis, it makes sense to reuse that
 code where applicable. *SkyLines* is using XCSoar as a python library. This library
-is build and installed by the `xcsoar` python package. To build this library you
+is built and installed by the `xcsoar` python package. To build this library you
 might have to install additional libraries like `libcurl`, which can be installed
 on Debian/Ubuntu by executing `apt-get install libcurl4-openssl-dev`. Please have
 a look into the XCSoar documentation if you need more help with the building process.

--- a/skylines/frontend/forms/pilot.py
+++ b/skylines/frontend/forms/pilot.py
@@ -53,7 +53,7 @@ class ChangePasswordForm(Form):
 
 
 class CreateClubPilotForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -86,7 +86,7 @@ class TrackingDelaySelectField(SelectField):
 
 
 class EditPilotForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -118,7 +118,7 @@ class LiveTrackingSettingsForm(Form):
 
 
 class RecoverStep1Form(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -133,7 +133,7 @@ class RecoverStep2Form(ChangePasswordForm):
 
 
 class LoginForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])

--- a/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
@@ -1326,7 +1326,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jste přihlášen(a). Wítejte zpátky, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1434,7 +1434,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/de/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/de/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgstr "Deine Passwörter stimmen nicht überein"
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "eMail Address"
+msgid "email Address"
 msgstr "E-Mail-Adresse"
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
@@ -1551,7 +1551,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du bist jetzt eingeloggt. Willkommen zurück, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Login fehlgeschlagen. Bitte prüfe deine E-Mail-Adresse."
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/en/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/en/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1437,7 +1437,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr ""
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/es/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/es/LC_MESSAGES/messages.po
@@ -1363,7 +1363,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Has iniciado sesión. Bienvenido, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1471,7 +1471,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Sus contraseñas no coinciden."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Correo electrónico"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
@@ -1354,7 +1354,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Olet nyt kirjautuneena sisään. Tervetuloa %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Sisäänkirjautuminen epäonnistui. Tarkista sähköpostiosoite."
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr "{num_missing} tiedostoa ({ids}) ei löytynyt tietokannasta."
 #~ msgid "Your passwords do not match."
 #~ msgstr "Salasanat eivät täsmää."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Sähköpostiosoite"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
@@ -1369,7 +1369,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "%(user)s vous êtes maintenant connecté !"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "La connexion a échoué. Veuillez vérifier votre adresse email."
 
 #: skylines/frontend/views/login.py:61
@@ -1477,7 +1477,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Vos mots de passe ne correspondent pas."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Adresse email"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jelenleg be vagy jelentkezve. Üdvözöllek %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "E-mail cím"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "ログインしました。%(user)sさん、ようこそ！"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,7 +1404,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Eメールアドレス"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/messages.pot
+++ b/skylines/frontend/translations/messages.pot
@@ -148,7 +148,7 @@ msgstr ""
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "eMail Address"
+msgid "email Address"
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
@@ -1490,7 +1490,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du er nå logget inn. Velkommen %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,7 +1411,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Epost"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
@@ -1361,7 +1361,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Je bent nu ingelogt. Welkom %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Inloggen is mislukt. Controleer uw e-mail adres."
 
 #: skylines/frontend/views/login.py:61
@@ -1469,7 +1469,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Uw paswoorden komen niet overeen."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "EMail adres"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
@@ -1380,7 +1380,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jesteś teraz zalogowany. Witaj ponownie, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Logowanie nieudane. Sprawdź adres e-mail."
 
 #: skylines/frontend/views/login.py:61
@@ -1488,7 +1488,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Hasła nie pasują do siebie."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Adres e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "A sua sessão foi iniciada com sucesso. Bem vindo(a), %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1407,7 +1407,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Endereço de e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
@@ -1309,7 +1309,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,7 +1411,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "adresa de mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Теперь вы подключены. Добро пожаловать, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Адрес эл. почты"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
@@ -1310,7 +1310,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Teraz ste prihlásený. Vitajte späť, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1416,7 +1416,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "E-mailová adresa"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
@@ -1307,7 +1307,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du är nu inloggad. Välkommen tillbaka, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1413,7 +1413,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Epostadress"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,7 +1404,7 @@ msgstr "對不起，在我們的資料庫中，沒有你查詢{num_missing} 的�
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "電郵地址"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/views/login.py
+++ b/skylines/frontend/views/login.py
@@ -57,7 +57,7 @@ def register(app):
                 flash(_('You are now logged in. Welcome back, %(user)s!', user=user))
                 return redirect(get_next())
             else:
-                form.email_address.errors.append(_('Login failed. Please check your eMail address.'))
+                form.email_address.errors.append(_('Login failed. Please check your email address.'))
                 form.password.errors.append(_('Login failed. Please check your password.'))
 
         return render_template('login.jinja', form=form, next=get_next())


### PR DESCRIPTION
I noticed that in some places on the website it was referring to `email` and in others it was referring to `eMail`.

I've gone through the translations and anywhere else this occurred and made everything consistent which should prevent things like this:
![skylinesemail](https://cloud.githubusercontent.com/assets/6305750/6516876/a1e404ac-c38d-11e4-910e-5b839aaeca3f.JPG)
