### PR TITLE
Email spelling UPDATED

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ by calling `./manage.py db create` from the the command line.
 Since the [XCSoar](http://www.xcsoar.org/) project already has much of the code
 implemented that is necessary for flight analysis, it makes sense to reuse that
 code where applicable. *SkyLines* is using XCSoar as a python library. This library
-is build and installed by the `xcsoar` python package. To build this library you
+is built and installed by the `xcsoar` python package. To build this library you
 might have to install additional libraries like `libcurl`, which can be installed
 on Debian/Ubuntu by executing `apt-get install libcurl4-openssl-dev`. Please have
 a look into the XCSoar documentation if you need more help with the building process.

--- a/skylines/frontend/forms/pilot.py
+++ b/skylines/frontend/forms/pilot.py
@@ -53,7 +53,7 @@ class ChangePasswordForm(Form):
 
 
 class CreateClubPilotForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -86,7 +86,7 @@ class TrackingDelaySelectField(SelectField):
 
 
 class EditPilotForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -118,7 +118,7 @@ class LiveTrackingSettingsForm(Form):
 
 
 class RecoverStep1Form(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])
@@ -133,7 +133,7 @@ class RecoverStep2Form(ChangePasswordForm):
 
 
 class LoginForm(Form):
-    email_address = EmailField(l_('eMail Address'), validators=[
+    email_address = EmailField(l_('email Address'), validators=[
         InputRequired(message=l_('Please enter your email address.')),
         Email(),
     ])

--- a/skylines/frontend/forms/pilot.py
+++ b/skylines/frontend/forms/pilot.py
@@ -53,8 +53,8 @@ class ChangePasswordForm(Form):
 
 
 class CreateClubPilotForm(Form):
-    email_address = EmailField(l_('email Address'), validators=[
-        InputRequired(message=l_('Please enter your email address.')),
+    email_address = EmailField(l_('Email Address'), validators=[
+        InputRequired(message=l_('Please enter your Email Address.')),
         Email(),
     ])
     first_name = TextField(l_('First Name'), validators=[
@@ -66,7 +66,7 @@ class CreateClubPilotForm(Form):
 
     def validate_email_address(form, field):
         if User.exists(email_address=field.data):
-            raise ValidationError(l_('A pilot with this email address exists already.'))
+            raise ValidationError(l_('A pilot with this Email Address exists already.'))
 
 
 class CreatePilotForm(CreateClubPilotForm, ChangePasswordForm):
@@ -86,8 +86,8 @@ class TrackingDelaySelectField(SelectField):
 
 
 class EditPilotForm(Form):
-    email_address = EmailField(l_('email Address'), validators=[
-        InputRequired(message=l_('Please enter your email address.')),
+    email_address = EmailField(l_('Email Address'), validators=[
+        InputRequired(message=l_('Please enter your Email Address.')),
         Email(),
     ])
     first_name = TextField(l_('First Name'), validators=[
@@ -107,7 +107,7 @@ class EditPilotForm(Form):
             return
 
         if User.exists(email_address=field.data):
-            raise ValidationError(l_('A pilot with this email address exists already.'))
+            raise ValidationError(l_('A pilot with this Email Address exists already.'))
 
 
 class LiveTrackingSettingsForm(Form):
@@ -118,14 +118,14 @@ class LiveTrackingSettingsForm(Form):
 
 
 class RecoverStep1Form(Form):
-    email_address = EmailField(l_('email Address'), validators=[
-        InputRequired(message=l_('Please enter your email address.')),
+    email_address = EmailField(l_('Email Address'), validators=[
+        InputRequired(message=l_('Please enter your Email Address.')),
         Email(),
     ])
 
     def validate_email_address(form, field):
         if not User.exists(email_address=field.data):
-            raise ValidationError(l_('There is no pilot with this email address.'))
+            raise ValidationError(l_('There is no pilot with this Email Address.'))
 
 
 class RecoverStep2Form(ChangePasswordForm):
@@ -133,8 +133,8 @@ class RecoverStep2Form(ChangePasswordForm):
 
 
 class LoginForm(Form):
-    email_address = EmailField(l_('email Address'), validators=[
-        InputRequired(message=l_('Please enter your email address.')),
+    email_address = EmailField(l_('Email Address'), validators=[
+        InputRequired(message=l_('Please enter your Email Address.')),
         Email(),
     ])
     password = PasswordField(l_('Password'), validators=[

--- a/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
@@ -1326,7 +1326,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jste přihlášen(a). Wítejte zpátky, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1434,10 +1434,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "e-mail"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1452,7 +1452,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1482,7 +1482,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/cs/LC_MESSAGES/messages.po
@@ -1326,7 +1326,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jste přihlášen(a). Wítejte zpátky, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1434,7 +1434,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/de/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/de/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgstr "Deine Passwörter stimmen nicht überein"
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "eMail Address"
+msgid "email Address"
 msgstr "E-Mail-Adresse"
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
@@ -1551,7 +1551,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du bist jetzt eingeloggt. Willkommen zurück, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Login fehlgeschlagen. Bitte prüfe deine E-Mail-Adresse."
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/de/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/de/LC_MESSAGES/messages.po
@@ -148,12 +148,12 @@ msgstr "Deine Passwörter stimmen nicht überein"
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "email Address"
+msgid "Email Address"
 msgstr "E-Mail-Adresse"
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
 #: skylines/frontend/forms/pilot.py:122 skylines/frontend/forms/pilot.py:137
-msgid "Please enter your email address."
+msgid "Please enter your Email Address."
 msgstr "Bitte gib deine E-Mail-Adresse ein."
 
 #: skylines/frontend/forms/pilot.py:60 skylines/frontend/forms/pilot.py:93
@@ -173,7 +173,7 @@ msgid "Please enter your last name."
 msgstr "Bitte gib deinen Nachnamen an."
 
 #: skylines/frontend/forms/pilot.py:69 skylines/frontend/forms/pilot.py:110
-msgid "A pilot with this email address exists already."
+msgid "A pilot with this Email Address exists already."
 msgstr "Ein Pilot mit dieser E-Mail-Adresse existiert bereits."
 
 #: skylines/frontend/forms/pilot.py:83
@@ -221,7 +221,7 @@ msgid "Your callsign must not have more than 5 characters."
 msgstr "Dein Kennzeichen darf maximal 5 Zeichen haben."
 
 #: skylines/frontend/forms/pilot.py:128
-msgid "There is no pilot with this email address."
+msgid "There is no pilot with this Email Address."
 msgstr "Ein Pilot mit dieser E-Mail-Adresse existiert nicht."
 
 #: skylines/frontend/forms/pilot.py:141
@@ -1551,7 +1551,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du bist jetzt eingeloggt. Willkommen zurück, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr "Login fehlgeschlagen. Bitte prüfe deine E-Mail-Adresse."
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/en/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/en/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1437,10 +1437,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr ""
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1455,7 +1455,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1485,7 +1485,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/en/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/en/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1437,7 +1437,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr ""
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/es/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/es/LC_MESSAGES/messages.po
@@ -1363,7 +1363,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Has iniciado sesión. Bienvenido, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1471,7 +1471,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Sus contraseñas no coinciden."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Correo electrónico"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/es/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/es/LC_MESSAGES/messages.po
@@ -1363,7 +1363,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Has iniciado sesión. Bienvenido, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1471,10 +1471,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Sus contraseñas no coinciden."
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Correo electrónico"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr "Por favor, ingrese su dirección de correo electrónico."
 
 #~ msgid "First Name"
@@ -1489,7 +1489,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr "Ya existe un piloto con esta dirección de correo electrónico."
 
 #~ msgid "None"
@@ -1519,7 +1519,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr "No existe ningún piloto con esta dirección de correo electrónico."
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
@@ -1354,7 +1354,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Olet nyt kirjautuneena sisään. Tervetuloa %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr "Sisäänkirjautuminen epäonnistui. Tarkista sähköpostiosoite."
 
 #: skylines/frontend/views/login.py:61
@@ -1458,10 +1458,10 @@ msgstr "{num_missing} tiedostoa ({ids}) ei löytynyt tietokannasta."
 #~ msgid "Your passwords do not match."
 #~ msgstr "Salasanat eivät täsmää."
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Sähköpostiosoite"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr "Syötä sähköpostiosoitteesi."
 
 #~ msgid "First Name"
@@ -1476,7 +1476,7 @@ msgstr "{num_missing} tiedostoa ({ids}) ei löytynyt tietokannasta."
 #~ msgid "Please enter your last name."
 #~ msgstr "Syötä sukunimesi."
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr "Sähköpostiosoite on jo käytössä."
 
 #~ msgid "None"
@@ -1506,7 +1506,7 @@ msgstr "{num_missing} tiedostoa ({ids}) ei löytynyt tietokannasta."
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr "Kutsumerkkisi ei voi olla yli viisi merkkiä pitkä."
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr "Sähköpostiosoitetta ei löytynyt."
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fi/LC_MESSAGES/messages.po
@@ -1354,7 +1354,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Olet nyt kirjautuneena sisään. Tervetuloa %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Sisäänkirjautuminen epäonnistui. Tarkista sähköpostiosoite."
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr "{num_missing} tiedostoa ({ids}) ei löytynyt tietokannasta."
 #~ msgid "Your passwords do not match."
 #~ msgstr "Salasanat eivät täsmää."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Sähköpostiosoite"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
@@ -1369,7 +1369,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "%(user)s vous êtes maintenant connecté !"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "La connexion a échoué. Veuillez vérifier votre adresse email."
 
 #: skylines/frontend/views/login.py:61
@@ -1477,7 +1477,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Vos mots de passe ne correspondent pas."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Adresse email"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/fr/LC_MESSAGES/messages.po
@@ -1369,8 +1369,8 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "%(user)s vous êtes maintenant connecté !"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
-msgstr "La connexion a échoué. Veuillez vérifier votre adresse email."
+msgid "Login failed. Please check your Email Address."
+msgstr "La connexion a échoué. Veuillez vérifier votre adresse e-mail."
 
 #: skylines/frontend/views/login.py:61
 msgid "Login failed. Please check your password."
@@ -1477,11 +1477,11 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Vos mots de passe ne correspondent pas."
 
-#~ msgid "email Address"
-#~ msgstr "Adresse email"
+#~ msgid "Email Address"
+#~ msgstr "adresse e-mail"
 
-#~ msgid "Please enter your email address."
-#~ msgstr "Veuillez saisir votre adresse email."
+#~ msgid "Please enter your Email Address."
+#~ msgstr "Veuillez saisir votre adresse e-mail."
 
 #~ msgid "First Name"
 #~ msgstr "Prénom"
@@ -1495,8 +1495,8 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr "Veuillez saisir votre nom de famille"
 
-#~ msgid "A pilot with this email address exists already."
-#~ msgstr "Un pilote ayant cette adresse email existe déjà."
+#~ msgid "A pilot with this Email Address exists already."
+#~ msgstr "Un pilote ayant cette adresse e-mail existe déjà."
 
 #~ msgid "None"
 #~ msgstr "Aucun"
@@ -1525,7 +1525,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr "Votre identifiant doit se limiter à 5 caractères."
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr "Il n'y a pas de pilote avec cette adresse."
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jelenleg be vagy jelentkezve. Üdvözöllek %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,10 +1458,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "E-mail cím"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1476,7 +1476,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1506,7 +1506,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/hu/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jelenleg be vagy jelentkezve. Üdvözöllek %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "E-mail cím"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "ログインしました。%(user)sさん、ようこそ！"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,10 +1404,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Eメールアドレス"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1422,7 +1422,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1452,7 +1452,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ja/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "ログインしました。%(user)sさん、ようこそ！"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,7 +1404,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Eメールアドレス"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/messages.pot
+++ b/skylines/frontend/translations/messages.pot
@@ -148,7 +148,7 @@ msgstr ""
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "eMail Address"
+msgid "email Address"
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
@@ -1490,7 +1490,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/messages.pot
+++ b/skylines/frontend/translations/messages.pot
@@ -148,12 +148,12 @@ msgstr ""
 
 #: skylines/frontend/forms/pilot.py:56 skylines/frontend/forms/pilot.py:89
 #: skylines/frontend/forms/pilot.py:121 skylines/frontend/forms/pilot.py:136
-msgid "email Address"
+msgid "Email Address"
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:57 skylines/frontend/forms/pilot.py:90
 #: skylines/frontend/forms/pilot.py:122 skylines/frontend/forms/pilot.py:137
-msgid "Please enter your email address."
+msgid "Please enter your Email Address."
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:60 skylines/frontend/forms/pilot.py:93
@@ -173,7 +173,7 @@ msgid "Please enter your last name."
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:69 skylines/frontend/forms/pilot.py:110
-msgid "A pilot with this email address exists already."
+msgid "A pilot with this Email Address exists already."
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:83
@@ -221,7 +221,7 @@ msgid "Your callsign must not have more than 5 characters."
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:128
-msgid "There is no pilot with this email address."
+msgid "There is no pilot with this Email Address."
 msgstr ""
 
 #: skylines/frontend/forms/pilot.py:141
@@ -1490,7 +1490,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61

--- a/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du er nå logget inn. Velkommen %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,10 +1411,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Epost"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1429,7 +1429,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1459,7 +1459,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nb/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du er nå logget inn. Velkommen %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,7 +1411,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Epost"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
@@ -1361,7 +1361,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Je bent nu ingelogt. Welkom %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr "Inloggen is mislukt. Controleer uw e-mail adres."
 
 #: skylines/frontend/views/login.py:61
@@ -1469,10 +1469,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Uw paswoorden komen niet overeen."
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "EMail adres"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr "Voer uw e-mailadres in."
 
 #~ msgid "First Name"
@@ -1487,7 +1487,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr "Geef uw achternaam."
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr "Een piloot met dit e-mail adres bestaat al."
 
 #~ msgid "None"
@@ -1517,7 +1517,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr "Uw callsign kan niet uit meer dan 5 tekens bestaan."
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr "Er is geen piloot met dit e-mail adres."
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/nl/LC_MESSAGES/messages.po
@@ -1361,7 +1361,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Je bent nu ingelogt. Welkom %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Inloggen is mislukt. Controleer uw e-mail adres."
 
 #: skylines/frontend/views/login.py:61
@@ -1469,7 +1469,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Uw paswoorden komen niet overeen."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "EMail adres"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
@@ -1380,7 +1380,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jesteś teraz zalogowany. Witaj ponownie, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr "Logowanie nieudane. Sprawdź adres e-mail."
 
 #: skylines/frontend/views/login.py:61
@@ -1488,10 +1488,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Hasła nie pasują do siebie."
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Adres e-mail"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr "Prosze wpisać swój adres e-mail."
 
 #~ msgid "First Name"
@@ -1506,7 +1506,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr "Wprowadź nazwisko."
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr "Pilot z tym adresem email już istnieje."
 
 #~ msgid "None"
@@ -1536,7 +1536,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr "Nie ma pilota z tym adresem email."
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pl/LC_MESSAGES/messages.po
@@ -1380,7 +1380,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Jesteś teraz zalogowany. Witaj ponownie, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr "Logowanie nieudane. Sprawdź adres e-mail."
 
 #: skylines/frontend/views/login.py:61
@@ -1488,7 +1488,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr "Hasła nie pasują do siebie."
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Adres e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "A sua sessão foi iniciada com sucesso. Bem vindo(a), %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1407,7 +1407,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Endereço de e-mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/pt/LC_MESSAGES/messages.po
@@ -1305,7 +1305,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "A sua sessão foi iniciada com sucesso. Bem vindo(a), %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1407,10 +1407,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Endereço de e-mail"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1425,7 +1425,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr "Um piloto com este nome já existe."
 
 #~ msgid "None"
@@ -1455,7 +1455,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
@@ -1309,7 +1309,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,7 +1411,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "adresa de mail"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ro/LC_MESSAGES/messages.po
@@ -1309,7 +1309,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1411,10 +1411,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "adresa de mail"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1429,7 +1429,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1459,7 +1459,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Теперь вы подключены. Добро пожаловать, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,10 +1458,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Адрес эл. почты"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1476,7 +1476,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1506,7 +1506,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/ru/LC_MESSAGES/messages.po
@@ -1350,7 +1350,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Теперь вы подключены. Добро пожаловать, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1458,7 +1458,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Адрес эл. почты"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
@@ -1310,7 +1310,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Teraz ste prihlásený. Vitajte späť, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1416,7 +1416,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "E-mailová adresa"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sk/LC_MESSAGES/messages.po
@@ -1310,7 +1310,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Teraz ste prihlásený. Vitajte späť, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1416,10 +1416,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "E-mailová adresa"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1434,7 +1434,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1464,7 +1464,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
@@ -1307,7 +1307,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du är nu inloggad. Välkommen tillbaka, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1413,10 +1413,10 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "Epostadress"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1431,7 +1431,7 @@ msgstr ""
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1461,7 +1461,7 @@ msgstr ""
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/sv/LC_MESSAGES/messages.po
@@ -1307,7 +1307,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr "Du är nu inloggad. Välkommen tillbaka, %(user)s!"
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1413,7 +1413,7 @@ msgstr ""
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "Epostadress"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your email address."
+msgid "Login failed. Please check your Email Address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,10 +1404,10 @@ msgstr "對不起，在我們的資料庫中，沒有你查詢{num_missing} 的�
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "email Address"
+#~ msgid "Email Address"
 #~ msgstr "電郵地址"
 
-#~ msgid "Please enter your email address."
+#~ msgid "Please enter your Email Address."
 #~ msgstr ""
 
 #~ msgid "First Name"
@@ -1422,7 +1422,7 @@ msgstr "對不起，在我們的資料庫中，沒有你查詢{num_missing} 的�
 #~ msgid "Please enter your last name."
 #~ msgstr ""
 
-#~ msgid "A pilot with this email address exists already."
+#~ msgid "A pilot with this Email Address exists already."
 #~ msgstr ""
 
 #~ msgid "None"
@@ -1452,7 +1452,7 @@ msgstr "對不起，在我們的資料庫中，沒有你查詢{num_missing} 的�
 #~ msgid "Your callsign must not have more than 5 characters."
 #~ msgstr ""
 
-#~ msgid "There is no pilot with this email address."
+#~ msgid "There is no pilot with this Email Address."
 #~ msgstr ""
 
 #~ msgid "Please enter your password."

--- a/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/skylines/frontend/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1302,7 +1302,7 @@ msgid "You are now logged in. Welcome back, %(user)s!"
 msgstr ""
 
 #: skylines/frontend/views/login.py:60
-msgid "Login failed. Please check your eMail address."
+msgid "Login failed. Please check your email address."
 msgstr ""
 
 #: skylines/frontend/views/login.py:61
@@ -1404,7 +1404,7 @@ msgstr "對不起，在我們的資料庫中，沒有你查詢{num_missing} 的�
 #~ msgid "Your passwords do not match."
 #~ msgstr ""
 
-#~ msgid "eMail Address"
+#~ msgid "email Address"
 #~ msgstr "電郵地址"
 
 #~ msgid "Please enter your email address."

--- a/skylines/frontend/views/login.py
+++ b/skylines/frontend/views/login.py
@@ -57,7 +57,7 @@ def register(app):
                 flash(_('You are now logged in. Welcome back, %(user)s!', user=user))
                 return redirect(get_next())
             else:
-                form.email_address.errors.append(_('Login failed. Please check your eMail address.'))
+                form.email_address.errors.append(_('Login failed. Please check your email address.'))
                 form.password.errors.append(_('Login failed. Please check your password.'))
 
         return render_template('login.jinja', form=form, next=get_next())

--- a/skylines/frontend/views/login.py
+++ b/skylines/frontend/views/login.py
@@ -57,7 +57,7 @@ def register(app):
                 flash(_('You are now logged in. Welcome back, %(user)s!', user=user))
                 return redirect(get_next())
             else:
-                form.email_address.errors.append(_('Login failed. Please check your email address.'))
+                form.email_address.errors.append(_('Login failed. Please check your Email Address.'))
                 form.password.errors.append(_('Login failed. Please check your password.'))
 
         return render_template('login.jinja', form=form, next=get_next())

--- a/skylines/frontend/views/settings.py
+++ b/skylines/frontend/views/settings.py
@@ -105,7 +105,7 @@ def password_recover():
 
     g.user.generate_recover_key(request.remote_addr)
     send_recover_mail(g.user)
-    flash('A password recovery email was sent to that user.')
+    flash('A password recovery Email was sent to that user.')
 
     db.session.commit()
 

--- a/skylines/model/user.py
+++ b/skylines/model/user.py
@@ -31,7 +31,7 @@ class User(db.Model):
 
     id = db.Column(Integer, autoincrement=True, primary_key=True)
 
-    # eMail address and name of the user
+    # Email Address and name of the user
 
     email_address = db.column_property(
         db.Column(Unicode(255)), comparator_factory=LowerCaseComparator)
@@ -101,13 +101,13 @@ class User(db.Model):
 
     @classmethod
     def by_email_address(cls, email):
-        """Return the user object whose email address is ``email``."""
+        """Return the user object whose Email Address is ``email``."""
         return cls.query(email_address=email).first()
 
     @classmethod
     def by_credentials(cls, email, password):
         """
-        Return the user object whose email address is ``email`` if the
+        Return the user object whose Email Address is ``email`` if the
         password is matching.
         """
         user = cls.query(email_address=email).first()

--- a/tests/frontend/functional/test_registration.py
+++ b/tests/frontend/functional/test_registration.py
@@ -88,10 +88,10 @@ class TestRegistration(TestController):
         """Validation errors are working as expected"""
 
         self.expect_error('Please enter your Email Address', email='')
-        self.expect_error('Invalid Email Address', email='abc')
-        self.expect_error('Invalid Email Address', email='abc@')
-        self.expect_error('Invalid Email Address', email='abc@de')
-        self.expect_error('Invalid Email Address', email='abc@de.')
+        self.expect_error('Invalid email address', email='abc')
+        self.expect_error('Invalid email address', email='abc@')
+        self.expect_error('Invalid email address', email='abc@de')
+        self.expect_error('Invalid email address', email='abc@de.')
 
         self.expect_error('Please enter your first name', first_name='')
         self.expect_error('Please enter your last name', last_name='')

--- a/tests/frontend/functional/test_registration.py
+++ b/tests/frontend/functional/test_registration.py
@@ -87,11 +87,11 @@ class TestRegistration(TestController):
     def test_validation_errors(self):
         """Validation errors are working as expected"""
 
-        self.expect_error('Please enter your email address', email='')
-        self.expect_error('Invalid email address', email='abc')
-        self.expect_error('Invalid email address', email='abc@')
-        self.expect_error('Invalid email address', email='abc@de')
-        self.expect_error('Invalid email address', email='abc@de.')
+        self.expect_error('Please enter your Email Address', email='')
+        self.expect_error('Invalid Email Address', email='abc')
+        self.expect_error('Invalid Email Address', email='abc@')
+        self.expect_error('Invalid Email Address', email='abc@de')
+        self.expect_error('Invalid Email Address', email='abc@de.')
 
         self.expect_error('Please enter your first name', first_name='')
         self.expect_error('Please enter your last name', last_name='')
@@ -109,5 +109,5 @@ class TestRegistration(TestController):
         last_name = u'Test'
 
         self.register_user(email, first_name, last_name, 'lambda')
-        self.expect_error('A pilot with this email address exists already.',
+        self.expect_error('A pilot with this Email Address exists already.',
                           email, first_name, last_name, 'lambda', check_user_exists=False)

--- a/tests/model/test_auth.py
+++ b/tests/model/test_auth.py
@@ -26,6 +26,6 @@ class TestUser(ModelTest):
         assert self.obj.admin == False
 
     def test_getting_by_email(self):
-        """Users should be fetcheable by their email addresses"""
+        """Users should be fetcheable by their Email Addresses"""
         him = model.User.by_email_address(u"ignucius@example.org")
         assert him == self.obj


### PR DESCRIPTION
Following discussion I've re-named "email" to "Email" and "email Address / eMail Address" to "Email Address" across the files where necessary.

I've also changed the French translations to "e-mail address" as per <a href="http://www.collinsdictionary.com/dictionary/english-french/email-address?showCookiePolicy=true">Collins dictionary</a>

Also a slight grammar change to INSTALL.md

Hope I haven't missed any! :)