### PR TITLE
Vagrant: Add missing xcsoar build dependencies.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     g++ pkg-config libcurl4-openssl-dev python-dev git \
     libpq-dev postgresql-9.4-postgis-2.1 postgresql-contrib-9.4 \
-    openjdk-7-jre-headless
+    openjdk-7-jre-headless libfreetype6-dev libpng-dev
 
 # install pip
 


### PR DESCRIPTION
The packages `freetype6-dev` and `libpng-dev` resolve missing build dependencies of py-xcsoar.

Probably these dependencies were added between py-xcsoar version 0.4 and 0.5[1]
at " 10df972c60308f22cfc9076ffe831754e535f5c5:require xcsoar==0.5".

[1]: aka xcsoar/xcsoar@36ec48d44bea6148c02cac74487b89d8a2bd35f9 and 6.8.2

