### PR TITLE
Fix/vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,15 +12,6 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=GTiff
 export POSTGIS_ENABLE_OUTDB_RASTERS=1
 EOF
 
-# adjust apt-get repository URLs
-
-sudo bash -c "cat > /etc/apt/sources.list" << EOF
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise-backports main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise-security main restricted universe multiverse
-EOF
-
 sudo bash -c "cat > /etc/apt/sources.list.d/pgdg.list" << EOF
 deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main
 EOF
@@ -89,8 +80,8 @@ sudo sudo -u postgres psql -d skylines_test -c 'CREATE EXTENSION fuzzystrmatch;'
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = 'ubuntu-12.04.2-x86_64'
-  config.vm.box_url = 'http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box'
+  # TravisCI uses a Precise Pangolin base image
+  config.vm.box = 'ubuntu/precise64'
 
   config.vm.network 'forwarded_port', guest: 5000, host: 5000
   config.vm.network 'forwarded_port', guest: 5001, host: 5001

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,29 +50,31 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /u
 wget -N -nv https://bootstrap.pypa.io/get-pip.py
 sudo -H python get-pip.py
 
-# install skylines frontend dependencies
-
-cd /vagrant/ember
+# install nvm, node 4.x, npm and bower
 
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
 
-# load nvm
 export NVM_DIR="/home/vagrant/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-nvm install 6
-npm install
-npm install -g bower
-bower install
-
-# build skylines frontend
-
-ember build
+nvm install 4
+npm install -g bower ember-cli phantomjs-prebuilt
 
 # install skylines and the python dependencies
 
 cd /vagrant
 sudo -H pip install -r requirements.txt --no-binary greenlet
+
+# install skylines frontend dependencies and build it
+
+cd ember
+
+npm install
+bower install
+
+ember build
+
+cd ..
 
 # create PostGIS databases
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,25 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /u
 wget -N -nv https://bootstrap.pypa.io/get-pip.py
 sudo -H python get-pip.py
 
+# install skylines frontend dependencies
+
+cd /vagrant/ember
+
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
+
+# load nvm
+export NVM_DIR="/home/vagrant/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+nvm install 6
+npm install
+npm install -g bower
+bower install
+
+# build skylines frontend
+
+ember build
+
 # install skylines and the python dependencies
 
 cd /vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,6 +104,12 @@ Vagrant.configure("2") do |config|
   # TravisCI uses a Precise Pangolin base image
   config.vm.box = 'ubuntu/precise64'
 
+  # increase memory size, required by 'npm install'
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
   config.vm.network 'forwarded_port', guest: 5000, host: 5000
   config.vm.network 'forwarded_port', guest: 5001, host: 5001
 


### PR DESCRIPTION
@Turbo87 This patch does not set the CPU count and memory size dynamically like you suggested, as we have no information about the host systems of other developers. Instead the minimal memory size required for `npm` was chosen (>1024 MB). ¯\\_(ツ)_/¯

Resolves #441 