### PR TITLE
Update Ember and dependencies

### DIFF
--- a/ember/bower.json
+++ b/ember/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "skylines",
   "dependencies": {
-    "ember": "~2.7.0",
+    "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
     "remarkable": "^1.6.2",
     "mocha": "~2.2.4",

--- a/ember/package.json
+++ b/ember/package.json
@@ -34,7 +34,6 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-cookies": "0.0.9",
     "ember-cp-validations": "2.9.3",
-    "ember-export-application-global": "^1.0.5",
     "ember-intl": "2.11.2",
     "ember-intl-cp-validations": "2.3.0",
     "ember-islands": "^1.0.2",

--- a/ember/package.json
+++ b/ember/package.json
@@ -26,7 +26,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-eslint": "1.6.0",
+    "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/ember/package.json
+++ b/ember/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.8.0",
-    "ember-cli-active-link-wrapper": "0.2.0",
+    "ember-cli-active-link-wrapper": "github:Turbo87/ember-cli-active-link-wrapper#005ea544",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/ember/package.json
+++ b/ember/package.json
@@ -31,8 +31,6 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-mocha": "^0.10.4",
-    "ember-cli-release": "^0.2.9",
-    "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cookies": "0.0.9",
     "ember-cp-validations": "2.9.3",

--- a/ember/package.json
+++ b/ember/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "^2.7.0",
+    "ember-cli": "2.8.0",
     "ember-cli-active-link-wrapper": "0.2.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",


### PR DESCRIPTION
This PR updates Ember, Ember CLI and a few other front-end dependencies. It also removes three unused dependencies from the `package.json` file.