### PR TITLE
Sentry error reporting

### DIFF
--- a/ember/app/services/raven.js
+++ b/ember/app/services/raven.js
@@ -1,0 +1,3 @@
+import RavenLogger from 'ember-cli-sentry/services/raven';
+
+export default RavenLogger;

--- a/ember/app/services/raven.js
+++ b/ember/app/services/raven.js
@@ -1,3 +1,7 @@
 import RavenLogger from 'ember-cli-sentry/services/raven';
 
-export default RavenLogger;
+export default RavenLogger.extend({
+  ignoreError(error) {
+    return error.name === 'TransitionAborted';
+  },
+});

--- a/ember/bower.json
+++ b/ember/bower.json
@@ -6,6 +6,7 @@
     "remarkable": "^1.6.2",
     "mocha": "~2.2.4",
     "chai": "~2.3.0",
-    "ember-mocha-adapter": "~0.3.1"
+    "ember-mocha-adapter": "~0.3.1",
+    "raven-js": "~3.3"
   }
 }

--- a/ember/config/environment.js
+++ b/ember/config/environment.js
@@ -19,12 +19,18 @@ module.exports = function(environment) {
 
     SKYLINES_API_URL: 'http://localhost:5001',
     SKYLINES_TILE_BASEURL: 'https://skylines.aero/mapproxy',
+
+    sentry: {
+      development: true,
+      dsn: 'https://1081e00b0f0e4965bae7b8b7e468edd3@sentry.io/102210',
+    },
   };
 
   if (environment === 'production') {
     ENV.SKYLINES_API_URL = 'https://api.skylines.aero';
     ENV.BING_API_KEY = 'AqYIkJFKZXzNxVnZmmDyk52su5Le7GLfzshBTu_px5N1HYa6B2KW2qPemRltfc8g';
     ENV.MAPBOX_TILE_URL = 'https://a.tiles.mapbox.com/v4/skylines.l9bfkoko/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic2t5bGluZXMiLCJhIjoiODR5cnAtcyJ9.OxutJHpnCaw6QQpxfl5ROA';
+    ENV.sentry.development = false;
   }
 
   if (environment === 'development') {

--- a/ember/package.json
+++ b/ember/package.json
@@ -31,6 +31,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-mocha": "^0.10.4",
+    "ember-cli-sentry": "2.4.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-cookies": "0.0.9",
     "ember-cp-validations": "2.9.3",

--- a/skylines/frontend/templates/base.jinja
+++ b/skylines/frontend/templates/base.jinja
@@ -52,19 +52,6 @@
 
 {% block scripts -%}
 
-{% if not debug %}
-<script type="text/javascript">
-window._trackJs = {
-  token: 'aca43f68272e47f1bf0c3f2f2d7b20f2',
-
-  onError: function (payload) {
-    return !(/404 NOT FOUND: GET \/tracking\/\d+\/json/).test(payload.message);
-  }
-}
-</script>
-<script type="text/javascript" src="https://cdn.trackjs.com/releases/current/tracker.js"></script>
-{% endif %}
-
 {%- assets 'all_js' %}
 <script type="text/javascript" src="{{ ASSET_URL }}"></script>
 {%- endassets %}

--- a/skylines/frontend/views/__init__.py
+++ b/skylines/frontend/views/__init__.py
@@ -56,10 +56,6 @@ def register(app):
     app.register_blueprint(users_blueprint, url_prefix='/users')
     app.register_blueprint(widgets_blueprint, url_prefix='/widgets')
 
-    @app.context_processor
-    def inject_debug():
-        return dict(debug=app.debug)
-
     @app.route('/')
     def index():
         return about()


### PR DESCRIPTION
aaaaand we're switching the error reporting again... after a few tests it seems that sentry is much better suited than trackjs, especially since they also support flask, which means we can use it for both frontend *and* backend. I've contacted them and we will very likely receive a sponsored account there too.