### PR TITLE
Eliminate global variables

### DIFF
--- a/ember/app/components/flight-page.js
+++ b/ember/app/components/flight-page.js
@@ -42,8 +42,6 @@ export default Ember.Component.extend({
       sidebar.open(window.location.hash.substring(1));
     }
 
-    let paddingFn = window.paddingFn = () => [20, 20, this.$('#barogram_panel').height() + 20, sidebar.width() + 20];
-
     let [primaryId, ...otherIds] = this.get('ids');
 
     let map = window.flightMap.get('map');
@@ -51,7 +49,7 @@ export default Ember.Component.extend({
     otherIds.forEach(id => fixCalc.addFlightFromJSON(`/flights/${id}/json`));
 
     let extent = fixCalc.get('flights').getBounds();
-    map.getView().fit(extent, map.getSize(), { padding: paddingFn() });
+    map.getView().fit(extent, map.getSize(), { padding: this._calculatePadding() });
 
     this.get('pinnedFlights.pinned')
       .filter(id => id !== primaryId)
@@ -68,6 +66,10 @@ export default Ember.Component.extend({
 
     return (interval.max == -Infinity) ? null : [interval.min, interval.max];
   }),
+
+  _calculatePadding() {
+    return [20, 20, this.$('#barogram_panel').height() + 20, this.$('#sidebar').width() + 20];
+  },
 
   actions: {
     togglePlayback() {
@@ -97,6 +99,10 @@ export default Ember.Component.extend({
         fixCalc.addFlightFromJSON(`/flights/${id}/json`);
         pinnedFlights.pin(id);
       }
+    },
+
+    calculatePadding() {
+      return this._calculatePadding();
     },
   },
 });

--- a/ember/app/components/phase-highlight-composer.js
+++ b/ember/app/components/phase-highlight-composer.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend({
     if (coordinates) {
       let map = this.get('map');
       let extent = ol.extent.boundingExtent(coordinates);
-      let padding = window.paddingFn();
+      let padding = this.getWithDefault('calculatePadding', Ember.K)();
       map.getView().fit(extent, map.getSize(), { padding });
     }
   },

--- a/ember/app/components/share-button.js
+++ b/ember/app/components/share-button.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  pinnedFlights: Ember.inject.service(),
+
   tagName: 'span',
 
   didInsertElement() {
-    let url = getShareUrl(location.origin + location.pathname);
+    let url = this.getShareUrl(location.origin + location.pathname);
 
     let content = `<div style="text-align:center">
       <input value="${url}" type="text" class="form-control" style="margin-bottom:9px">
@@ -29,23 +31,23 @@ export default Ember.Component.extend({
       template: popover_template,
     });
   },
+
+  /**
+   * Returns the URL for the current page and add pinned flights
+   * to the URL which are only stored client-side inside a cookie.
+   *
+   * @param {String} url The original URL.
+   * @return {String} URL for the current flights including pinned flights.
+   */
+  getShareUrl(url) {
+    let pinnedFlights = this.get('pinnedFlights.pinned');
+
+    let url_re = /(.*?)\/([\d,]{1,})\/(.*)/;
+    let url_split = url_re.exec(url);
+
+    let url_ids = url_split[2].split(',').map(it => parseInt(it, 10));
+    let unique_ids = url_ids.concat(pinnedFlights).uniq();
+
+    return `${url_split[1]}/${unique_ids.join(',')}/${url_split[3]}`;
+  },
 });
-
-/**
- * Returns the URL for the current page and add pinned flights
- * to the URL which are only stored client-side inside a cookie.
- *
- * @param {String} url The original URL.
- * @return {String} URL for the current flights including pinned flights.
- */
-function getShareUrl(url) {
-  let pinnedFlights = window.pinnedFlightsService.get('pinned');
-
-  let url_re = /(.*?)\/([\d,]{1,})\/(.*)/;
-  let url_split = url_re.exec(url);
-
-  let url_ids = url_split[2].split(',').map(it => parseInt(it, 10));
-  let unique_ids = url_ids.concat(pinnedFlights).uniq();
-
-  return `${url_split[1]}/${unique_ids.join(',')}/${url_split[3]}`;
-}

--- a/ember/app/components/takeoffs-map.js
+++ b/ember/app/components/takeoffs-map.js
@@ -5,6 +5,7 @@ import slMapClickHandler from '../utils/map-click-handler';
 export default BaseMapComponent.extend({
   didInsertElement() {
     this._super(...arguments);
+    this.fit();
     slMapClickHandler(this.get('map'));
   },
 

--- a/ember/app/components/takeoffs-map.js
+++ b/ember/app/components/takeoffs-map.js
@@ -1,6 +1,13 @@
 import BaseMapComponent from './base-map';
 
+import slMapClickHandler from '../utils/map-click-handler';
+
 export default BaseMapComponent.extend({
+  didInsertElement() {
+    this._super(...arguments);
+    slMapClickHandler(this.get('map'));
+  },
+
   fit() {
     let map = this.get('map');
 

--- a/ember/app/components/tracking-page.js
+++ b/ember/app/components/tracking-page.js
@@ -39,8 +39,6 @@ export default Ember.Component.extend({
       sidebar.open(window.location.hash.substring(1));
     }
 
-    let paddingFn = window.paddingFn = () => [20, 20, this.$('#barogram_panel').height() + 20, sidebar.width() + 20];
-
     let map = window.flightMap.get('map');
 
     fixCalc.set('defaultTime', -1);
@@ -49,7 +47,7 @@ export default Ember.Component.extend({
     flights.forEach(flight => fixCalc.addFlight(flight));
 
     let extent = fixCalc.get('flights').getBounds();
-    map.getView().fit(extent, map.getSize(), { padding: paddingFn() });
+    map.getView().fit(extent, map.getSize(), { padding: this._calculatePadding() });
 
     // update flight track every 15 seconds
     this._scheduleUpdate();
@@ -94,6 +92,10 @@ export default Ember.Component.extend({
     return (interval.max == -Infinity) ? null : [interval.min, interval.max];
   }),
 
+  _calculatePadding() {
+    return [20, 20, this.$('#barogram_panel').height() + 20, this.$('#sidebar').width() + 20];
+  },
+
   actions: {
     togglePlayback() {
       this.get('fixCalc').togglePlayback();
@@ -102,6 +104,10 @@ export default Ember.Component.extend({
     removeFlight(id) {
       let flights = this.get('fixCalc.flights');
       flights.removeObjects(flights.filterBy('id', id));
+    },
+
+    calculatePadding() {
+      return this._calculatePadding();
     },
   },
 });

--- a/ember/app/components/user-page.js
+++ b/ember/app/components/user-page.js
@@ -2,9 +2,5 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   didInsertElement() {
-    let map = window.flightMap;
-    if (map) {
-      map.fit();
-    }
   },
 });

--- a/ember/app/components/user-page.js
+++ b/ember/app/components/user-page.js
@@ -1,13 +1,10 @@
 import Ember from 'ember';
 
-import slMapClickHandler from '../utils/map-click-handler';
-
 export default Ember.Component.extend({
   didInsertElement() {
     let map = window.flightMap;
     if (map) {
       map.fit();
-      slMapClickHandler(map.get('map'));
     }
   },
 });

--- a/ember/app/components/user-page.js
+++ b/ember/app/components/user-page.js
@@ -1,6 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-  didInsertElement() {
-  },
-});

--- a/ember/app/services/cesium-loader.js
+++ b/ember/app/services/cesium-loader.js
@@ -5,11 +5,6 @@ const CESIUM_BASE_URL = '/cesium/';
 export default Ember.Service.extend({
   loaderPromise: null,
 
-  init() {
-    this._super(...arguments);
-    window.cesiumLoader = this;
-  },
-
   load() {
     let promise = this.get('loaderPromise');
     if (!promise) {

--- a/ember/app/services/pinned-flights.js
+++ b/ember/app/services/pinned-flights.js
@@ -6,8 +6,6 @@ export default Ember.Service.extend({
   init() {
     this._super(...arguments);
     this.load();
-
-    window.pinnedFlightsService = this;
   },
 
   pin(id) {

--- a/ember/app/templates/components/flight-map.hbs
+++ b/ember/app/templates/components/flight-map.hbs
@@ -3,7 +3,7 @@
 {{#if flights}}
   {{cesium-button enabled=cesiumEnabled onEnable=(action "cesiumEnabled") onDisable=(action "cesiumDisabled") style="top:200px"}}
   {{flight-path-layer map=map flights=flights}}
-  {{phase-highlight-composer map=map coordinates=phaseHighlightCoords}}
+  {{phase-highlight-composer map=map coordinates=phaseHighlightCoords calculatePadding=calculatePadding}}
   {{plane-icons-composer map=map fixes=fixes}}
   {{contest-layer map=map flights=flights visible=(not cesiumEnabled)}}
 

--- a/ember/app/templates/components/flight-page.hbs
+++ b/ember/app/templates/components/flight-page.hbs
@@ -92,6 +92,7 @@
   onExtentChange=(action (mut mapExtent))
   onCesiumEnabledChange=(action (mut cesiumEnabled))
   addFlight=(action "addFlight")
+  calculatePadding=(action "calculatePadding")
   class="olFullscreen sidebar-map"}}
 
   {{fullscreen-button fullscreenElement="#fullscreen-content"}}

--- a/ember/app/templates/components/tracking-page.hbs
+++ b/ember/app/templates/components/tracking-page.hbs
@@ -27,6 +27,7 @@
     onTimeChange=(action (mut fixCalc.time))
     onExtentChange=(action (mut mapExtent))
     onCesiumEnabledChange=(action (mut cesiumEnabled))
+    calculatePadding=(action "calculatePadding")
     class="olFullscreen sidebar-map"}}
 
     {{fullscreen-button fullscreenElement="#fullscreen-content"}}


### PR DESCRIPTION
The `flightMap` global still remains, but this PR at least gets rid of all the others... 🎉 