### PR TITLE
templates/settings/club: Use "readonly" helper

### DIFF
--- a/ember/app/templates/settings/club.hbs
+++ b/ember/app/templates/settings/club.hbs
@@ -1,4 +1,4 @@
 {{#settings-page title=(t "change-club")}}
-  {{settings-panels/choose-club clubs=model.clubs clubId=account.club.id}}
+  {{settings-panels/choose-club clubs=model.clubs clubId=(readonly account.club.id)}}
   {{settings-panels/register-club}}
 {{/settings-page}}


### PR DESCRIPTION
This makes sure we don't try to set `account.club.id` when `account.club` isn't set.

Resolves #509