### PR TITLE
tracking: redirect old route with /map suffix

### DIFF
--- a/ember/app/router.js
+++ b/ember/app/router.js
@@ -50,6 +50,7 @@ Router.map(function() {
   this.route('tracking', function() {
     this.route('info');
     this.route('details', { path: '/:user_ids' });
+    this.route('map-redirect', { path: '/:user_ids/map' });
   });
 
   this.route('ranking', function() {

--- a/ember/app/routes/tracking/map-redirect.js
+++ b/ember/app/routes/tracking/map-redirect.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect({ user_ids }) {
+    this.transitionTo('tracking.details', user_ids);
+  },
+});


### PR DESCRIPTION
Redirect the old /tracking/:user_ids/map route to /tracking/:user_ids, fixes #512 
