### PR TITLE
Go to flight upload page when flight upload navbar link is clicked

### DIFF
--- a/ember/app/controllers/application.js
+++ b/ember/app/controllers/application.js
@@ -8,5 +8,9 @@ export default Ember.Controller.extend({
       });
       return false;
     },
+
+    resetUploadController() {
+      this.get('uploadController').set('result', null);
+    },
   },
 });

--- a/ember/app/routes/application.js
+++ b/ember/app/routes/application.js
@@ -33,7 +33,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     return this.get('ajax').request('/locale', { data }).then(it => it.locale || 'en');
   },
 
-  setupController() {
+  setupController(controller) {
+    this._super(...arguments);
+
     let settings = this.get('session.data.authenticated.settings');
     if (settings) {
       this.get('units').setProperties({
@@ -43,6 +45,8 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
         speedUnitIndex: settings.speedUnit,
       });
     }
+
+    controller.set('uploadController', this.controllerFor('flight-upload'));
   },
 
   activate() {

--- a/ember/app/templates/application.hbs
+++ b/ember/app/templates/application.hbs
@@ -1,5 +1,5 @@
 {{title "SkyLines"}}
 
-{{nav-bar onSearch=(action "search")}}
+{{nav-bar onSearch=(action "search") didClickUpload=(action "resetUploadController")}}
 
 {{outlet}}

--- a/ember/app/templates/components/nav-bar-menu-right.hbs
+++ b/ember/app/templates/components/nav-bar-menu-right.hbs
@@ -1,5 +1,5 @@
 {{#active-link}}
-  {{#link-to "flight-upload"title=(t "upload-flight")}}
+  {{#link-to "flight-upload" click=didClickUpload title=(t "upload-flight")}}
     {{fa-icon "upload" size="lg" class="hidden-xs"}}
     {{fa-icon "upload" fixedWidth=true class="visible-xs"}}
     <span class="visible-xs">{{t "upload-flight"}}</span>

--- a/ember/app/templates/components/nav-bar.hbs
+++ b/ember/app/templates/components/nav-bar.hbs
@@ -11,6 +11,6 @@
   <div class="collapse navbar-collapse navbar-ex1-collapse">
     {{nav-bar-menu}}
     {{nav-bar-search-form onSearch=onSearch}}
-    {{nav-bar-menu-right}}
+    {{nav-bar-menu-right didClickUpload=didClickUpload}}
   </div>
 </div>


### PR DESCRIPTION
Previously the link transitioned back to the `flight-upload` route, but without resetting the controller. This meant that after uploading a flight there was no way to get back to the flight upload form without a page refresh, because you're always being directed to the upload results page.