### PR TITLE
Fix tracking info page

### DIFF
--- a/ember/app/routes/tracking/info.js
+++ b/ember/app/routes/tracking/info.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
   model() {
     let userId = this.get('account.user.id');
     if (userId) {
-      return this.get('ajax').request(`/api/users/${userId}`);
+      return this.get('ajax').request('/api/settings');
     }
   },
 });


### PR DESCRIPTION
The tracking info page previously suggested to login to view the live tracking key while already being logged in.