### PR TITLE
flights: redirect old route with /map suffix

### DIFF
--- a/ember/app/router.js
+++ b/ember/app/router.js
@@ -33,6 +33,7 @@ Router.map(function() {
   this.route('flight', { path: '/flights/:flight_ids' }, function() {
     this.route('change-aircraft', { path: '/change_aircraft' });
     this.route('change-pilot', { path: '/change_pilot' });
+    this.route('map-redirect', { path: '/map' });
   });
 
   this.route('flights', { path: '/flights' }, function() {

--- a/ember/app/routes/flight/map-redirect.js
+++ b/ember/app/routes/flight/map-redirect.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect() {
+    this.transitionTo('flight.index');
+  },
+});


### PR DESCRIPTION
This redirects the old /flights/<ids>/map route, fixes #554