### PR TITLE
Vagrant: Set "postgres" DB user password for Vagrant dev machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,8 @@ sudo sudo -u postgres createdb skylines_test -O vagrant
 sudo sudo -u postgres psql -d skylines_test -c 'CREATE EXTENSION postgis;'
 sudo sudo -u postgres psql -d skylines_test -c 'CREATE EXTENSION fuzzystrmatch;'
 
+sudo sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'secret123';"
+
 ./manage.py db create
 
 # create folder for downloaded files


### PR DESCRIPTION
This allows us to access the DB from outside the VM via SSH tunneling