### PR TITLE
Update Ember to v2.10.0

### DIFF
--- a/ember/.gitignore
+++ b/ember/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist

--- a/ember/.travis.yml
+++ b/ember/.travis.yml
@@ -7,7 +7,8 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 before_install:
   - npm config set spin false

--- a/ember/README.md
+++ b/ember/README.md
@@ -7,10 +7,10 @@ A short introduction of this app could easily go here.
 
 You will need the following things properly installed on your computer.
 
-* [Git](http://git-scm.com/)
-* [Node.js](http://nodejs.org/) (with NPM)
-* [Bower](http://bower.io/)
-* [Ember CLI](http://ember-cli.com/)
+* [Git](https://git-scm.com/)
+* [Node.js](https://nodejs.org/) (with NPM)
+* [Bower](https://bower.io/)
+* [Ember CLI](https://ember-cli.com/)
 * [PhantomJS](http://phantomjs.org/)
 
 ## Installation
@@ -46,8 +46,7 @@ Specify what it takes to deploy your app.
 ## Further Reading / Useful Links
 
 * [ember.js](http://emberjs.com/)
-* [ember-cli](http://ember-cli.com/)
+* [ember-cli](https://ember-cli.com/)
 * Development Browser Extensions
   * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
   * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
-

--- a/ember/bower.json
+++ b/ember/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "skylines",
   "dependencies": {
-    "ember": "~2.10.0-beta.3",
+    "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3",
     "remarkable": "^1.6.2",
     "ember-mocha-adapter": "~0.3.1",

--- a/ember/package.json
+++ b/ember/package.json
@@ -2,26 +2,22 @@
   "name": "skylines",
   "version": "0.0.0",
   "description": "Small description for skylines goes here",
-  "private": true,
+  "license": "MIT",
+  "author": "",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
     "test": "ember test"
   },
-  "repository": "",
-  "engines": {
-    "node": ">= 0.12.0"
-  },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "^2.9.1",
+    "ember-cli": "2.10.0",
     "ember-cli-active-link-wrapper": "^0.3.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",
@@ -55,5 +51,9 @@
     "ember-simple-auth": "1.1.0",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.10"
-  }
+  },
+  "engines": {
+    "node": ">= 0.12.0"
+  },
+  "private": true
 }


### PR DESCRIPTION
This is mostly just following https://github.com/ember-cli/ember-new-output/compare/v2.9.1...v2.10.0 and brings us back onto a stable Ember.js release including the new Glimmer rendering engine.