### PR TITLE
Show different symbols on map depending on aircraft type

### DIFF
--- a/ember/app/components/plane-icons-composer.js
+++ b/ember/app/components/plane-icons-composer.js
@@ -14,22 +14,47 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
 
+    this.set('icons', {});
+    this.set('styles', {});
+
+    this._initStyle('glider', {
+      size: [40, 24],
+      src: '/images/glider_symbol.png',
+    });
+
+    this._initStyle('motorglider', {
+      size: [40, 24],
+      src: '/images/motorglider_symbol.png',
+    });
+
+    this._initStyle('paraglider', {
+      size: [40, 24],
+      src: '/images/paraglider_symbol.png',
+    });
+
+    this._initStyle('hangglider', {
+      size: [40, 14],
+      src: '/images/hangglider_symbol.png',
+    });
+  },
+
+  _initStyle(key, { src, size }) {
     let icon = new ol.style.Icon({
       anchor: [0.5, 0.5],
       anchorXUnits: 'fraction',
       anchorYUnits: 'fraction',
-      size: [40, 24],
-      src: '/images/glider_symbol.png',
+      size,
+      src,
       rotation: 0,
       rotateWithView: true,
     });
 
     icon.load();
 
-    this.set('icon', icon);
-
     let style = new ol.style.Style({ image: icon });
-    this.set('style', style);
+
+    this.set(`icons.${key}`, icon);
+    this.set(`styles.${key}`, style);
   },
 
   didInsertElement() {
@@ -45,12 +70,17 @@ export default Ember.Component.extend({
   },
 
   renderIcons(context) {
-    let icon = this.get('icon');
-    let style = this.get('style');
+    let icons = this.get('icons');
+    let styles = this.get('styles');
 
     this.get('fixes').forEach(fix => {
       let point = fix.get('pointXY');
+
       if (point) {
+        let type = Ember.getWithDefault(fix, 'flight.model.type', 'glider');
+        let icon = icons[type] || icons['glider'];
+        let style = styles[type] || styles['glider'];
+
         icon.setRotation(fix.get('heading'));
         context.setStyle(style);
         context.drawGeometry(point);

--- a/ember/app/utils/flight-from-data.js
+++ b/ember/app/utils/flight-from-data.js
@@ -47,5 +47,6 @@ export default function(data, units) {
     geoid: data.geoid,
     competition_id: additional.competition_id,
     registration: additional.registration,
+    model: additional.model,
   });
 }

--- a/ember/app/utils/flight.js
+++ b/ember/app/utils/flight.js
@@ -56,6 +56,8 @@ export default Ember.Object.extend({
     this.get('geometry').setCoordinates(coordinates, 'XYZM');
   }),
 
+  model: null,
+
   init() {
     this._super(...arguments);
     this.set('geometry', new ol.geom.LineString(this.get('coordinates'), 'XYZM'));

--- a/skylines/api/views/flights.py
+++ b/skylines/api/views/flights.py
@@ -461,10 +461,7 @@ def json(flight_id):
     if not trace:
         abort(404)
 
-    if flight.model:
-        model = AircraftModelSchema().dump(flight.model).data
-    else:
-        model = None
+    model = AircraftModelSchema().dump(flight.model).data or None
 
     resp = make_response(jsonify(
         points=trace['points'],

--- a/skylines/api/views/flights.py
+++ b/skylines/api/views/flights.py
@@ -438,7 +438,7 @@ def read(flight_id):
 @flights_blueprint.route('/flights/<flight_id>/json')
 @oauth.optional()
 def json(flight_id):
-    flight = get_requested_record(Flight, flight_id, joinedload=[Flight.igc_file])
+    flight = get_requested_record(Flight, flight_id, joinedload=(Flight.igc_file, Flight.model))
 
     current_user = User.get(request.user_id) if request.user_id else None
     if not flight.is_viewable(current_user):

--- a/skylines/api/views/flights.py
+++ b/skylines/api/views/flights.py
@@ -30,7 +30,7 @@ from skylines.model import (
 from skylines.model.event import create_flight_comment_notifications
 from skylines.schemas import (
     fields, FlightSchema, FlightCommentSchema, FlightPhaseSchema, ContestLegSchema,
-    AirportSchema, ClubSchema, UserSchema, Schema, ValidationError
+    AircraftModelSchema, AirportSchema, ClubSchema, UserSchema, Schema, ValidationError
 )
 from skylines.worker import tasks
 
@@ -461,6 +461,11 @@ def json(flight_id):
     if not trace:
         abort(404)
 
+    if flight.model:
+        model = AircraftModelSchema().dump(flight.model).data
+    else:
+        model = None
+
     resp = make_response(jsonify(
         points=trace['points'],
         barogram_t=trace['barogram_t'],
@@ -473,7 +478,8 @@ def json(flight_id):
         geoid=trace['geoid'],
         additional=dict(
             registration=flight.registration,
-            competition_id=flight.competition_id)))
+            competition_id=flight.competition_id,
+            model=model)))
 
     resp.headers['Last-Modified'] = last_modified
     resp.headers['Etag'] = flight.igc_file.md5

--- a/skylines/lib/dbutil.py
+++ b/skylines/lib/dbutil.py
@@ -7,8 +7,8 @@ from sqlalchemy import orm
 
 
 def _patch_query(q, joinedload=(), patch_query=None):
-    if joinedload:
-        q = q.options(orm.joinedload(*joinedload))
+    for join in joinedload:
+        q = q.options(orm.joinedload(join))
 
     if patch_query:
         q = patch_query(q)


### PR DESCRIPTION
![bildschirmfoto 2016-12-21 um 10 59 56](https://cloud.githubusercontent.com/assets/141300/21384890/a28eaecc-c76c-11e6-99b4-c256ee7b5cbf.png)

This PR implements the server and client code to switch aircraft symbols on the map depending on the type of aircraft assigned to the flight.

Resolves #545 
Resolves #546
Closes #558

Thanks @pyrog for working on this! I don't know what I did wrong in https://github.com/skylines-project/skylines/pull/558#issuecomment-263116862, but when I tried it again it suddenly worked. I've updated your commits to the current state of `master` and adjusted a few small things.