### PR TITLE
Remove "title" properties from "link-to" components

### DIFF
--- a/ember/app/templates/components/nav-bar-link.hbs
+++ b/ember/app/templates/components/nav-bar-link.hbs
@@ -1,6 +1,6 @@
 {{#active-link class=listClass}}
-  {{#link-to target title=title}}
-    {{fa-icon icon size="lg" class="visible-sm-inline-block"}}
+  {{#link-to target}}
+    {{fa-icon icon size="lg" class="visible-sm-inline-block" title=title}}
     {{fa-icon icon fixedWidth=true class="visible-xs-inline-block"}}
     <span class="hidden-sm">{{title}}</span>
   {{/link-to}}

--- a/ember/app/templates/components/nav-bar-menu-right.hbs
+++ b/ember/app/templates/components/nav-bar-menu-right.hbs
@@ -1,6 +1,6 @@
 {{#active-link}}
-  {{#link-to "flight-upload" click=didClickUpload title=(t "upload-flight")}}
-    {{fa-icon "upload" size="lg" class="hidden-xs"}}
+  {{#link-to "flight-upload" click=didClickUpload}}
+    {{fa-icon "upload" size="lg" class="hidden-xs" title=(t "upload-flight")}}
     {{fa-icon "upload" fixedWidth=true class="visible-xs-inline-block"}}
     <span class="visible-xs-inline-block">{{t "upload-flight"}}</span>
   {{/link-to}}
@@ -8,9 +8,9 @@
 
 {{#if session.isAuthenticated}}
   {{#active-link}}
-    {{#link-to "notifications" title=(t "notifications")}}
+    {{#link-to "notifications"}}
       <span class="visible-xs-inline-block">{{t "notifications"}}&nbsp;&nbsp;</span>
-      {{notifications-badge}}
+      <span title={{t "notifications"}}>{{notifications-badge}}</span>
     {{/link-to}}
   {{/active-link}}
 


### PR DESCRIPTION
works around https://github.com/alexspeller/ember-cli-active-link-wrapper/issues/25