### PR TITLE
Ember: Load translations async

### DIFF
--- a/ember/app/components/nav-bar-menu-right.js
+++ b/ember/app/components/nav-bar-menu-right.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
 
   actions: {
     setLocale(locale) {
-      this.get('intl').setLocale(locale);
+      this.get('intl').loadAndSetLocale(locale);
     },
   },
 });

--- a/ember/app/routes/application.js
+++ b/ember/app/routes/application.js
@@ -15,7 +15,8 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   units: Ember.inject.service(),
 
   beforeModel() {
-    return this._determineLocale().then(locale => this.get('intl').setLocale(locale));
+    return this._determineLocale()
+      .then(locale => this.get('intl').loadAndSetLocale(locale));
   },
 
   _determineLocale() {

--- a/ember/app/services/intl.js
+++ b/ember/app/services/intl.js
@@ -2,7 +2,21 @@ import Ember from 'ember';
 import IntlService from 'ember-intl/services/intl';
 
 export default IntlService.extend({
+  ajax: Ember.inject.service(),
   cookies: Ember.inject.service(),
+
+  loadAndSetLocale(locale) {
+    return this.loadLocale(locale).then(() => this.setLocale(locale));
+  },
+
+  loadLocale(locale) {
+    if (this.exists('yes', locale)) {
+      return Ember.RSVP.resolve();
+    }
+
+    return this.get('ajax').request(`/translations/${locale}.json`)
+      .then(translations => this.addTranslations(locale, translations));
+  },
 
   setLocale(locale) {
     Ember.debug(`Setting locale to "${locale}"`);

--- a/ember/config/ember-intl.js
+++ b/ember/config/ember-intl.js
@@ -56,7 +56,7 @@ module.exports = function(/* env */) {
     * @type {Boolean}
     * @default "false"
     */
-    publicOnly: false,
+    publicOnly: true,
 
     inputPath: 'translations',
     outputPath: 'translations',

--- a/ember/tests/acceptance/page-not-found-test.js
+++ b/ember/tests/acceptance/page-not-found-test.js
@@ -1,5 +1,6 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 

--- a/ember/tests/integration/components/flight-list-nav-test.js
+++ b/ember/tests/integration/components/flight-list-nav-test.js
@@ -26,7 +26,7 @@ describe('Integration: FlightListNavComponent', function() {
     this.inject.service('account', { as: 'account' });
     this.inject.service('pinned-flights', { as: 'pinned' });
 
-    this.get('intl').setLocale(['en']);
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default view', function() {
@@ -41,7 +41,7 @@ describe('Integration: FlightListNavComponent', function() {
     expect(this.$('li')).to.have.length(4);
     expect(this.$('li:nth-child(1)').text().trim()).to.equal('All');
     expect(this.$('li:nth-child(2)').text().trim()).to.equal('');
-    expect(this.$('li:nth-child(3)').text().trim()).to.equal('6/24/2016');
+    expect(this.$('li:nth-child(3)').text().trim()).to.match(/0?6\/24\/2016/);
     expect(this.$('li:nth-child(4)').text().trim()).to.equal('');
   });
 
@@ -50,7 +50,7 @@ describe('Integration: FlightListNavComponent', function() {
     expect(this.$('li')).to.have.length(4);
     expect(this.$('li:nth-child(1)').text().trim()).to.equal('All');
     expect(this.$('li:nth-child(2)').text().trim()).to.equal('');
-    expect(this.$('li:nth-child(3)').text().trim()).to.equal('6/24/2016');
+    expect(this.$('li:nth-child(3)').text().trim()).to.match(/0?6\/24\/2016/);
     expect(this.$('li:nth-child(4)').text().trim()).to.equal('');
   });
 

--- a/ember/tests/integration/components/flight-list-nav-test.js
+++ b/ember/tests/integration/components/flight-list-nav-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: FlightListNavComponent', function() {
+describe('Integration | Component | flight list nav', function() {
   setupComponentTest('flight-list-nav', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/integration/components/timeline-events/club-join-test.js
+++ b/ember/tests/integration/components/timeline-events/club-join-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: ClubJoinTimelineEventComponent', function() {
+describe('Integration | Component | timeline events/club join', function() {
   setupComponentTest('timeline-events/club-join', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/integration/components/timeline-events/club-join-test.js
+++ b/ember/tests/integration/components/timeline-events/club-join-test.js
@@ -21,8 +21,6 @@ describe('Integration: ClubJoinTimelineEventComponent', function() {
     this.inject.service('intl', { as: 'intl' });
     this.inject.service('account', { as: 'account' });
 
-    this.get('intl').setLocale('en');
-
     this.set('event', {
       time: '2016-06-24T12:34:56Z',
       actor: {
@@ -34,6 +32,8 @@ describe('Integration: ClubJoinTimelineEventComponent', function() {
         name: 'SFN',
       },
     });
+
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default text', function() {

--- a/ember/tests/integration/components/timeline-events/flight-comment-test.js
+++ b/ember/tests/integration/components/timeline-events/flight-comment-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: FlightCommentTimelineEventComponent', function() {
+describe('Integration | Component | timeline events/flight comment', function() {
   setupComponentTest('timeline-events/flight-comment', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/integration/components/timeline-events/flight-comment-test.js
+++ b/ember/tests/integration/components/timeline-events/flight-comment-test.js
@@ -21,8 +21,6 @@ describe('Integration: FlightCommentTimelineEventComponent', function() {
     this.inject.service('intl', { as: 'intl' });
     this.inject.service('account', { as: 'account' });
 
-    this.get('intl').setLocale('en');
-
     this.set('event', {
       time: '2016-06-24T12:34:56Z',
       actor: {
@@ -37,6 +35,8 @@ describe('Integration: FlightCommentTimelineEventComponent', function() {
         copilot_id: null,
       },
     });
+
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default text', function() {

--- a/ember/tests/integration/components/timeline-events/flight-upload-test.js
+++ b/ember/tests/integration/components/timeline-events/flight-upload-test.js
@@ -21,8 +21,6 @@ describe('Integration: FlightUploadTimelineEventComponent', function() {
     this.inject.service('intl', { as: 'intl' });
     this.inject.service('account', { as: 'account' });
 
-    this.get('intl').setLocale('en');
-
     this.set('event', {
       time: '2016-06-24T12:34:56Z',
       actor: {
@@ -37,6 +35,8 @@ describe('Integration: FlightUploadTimelineEventComponent', function() {
         copilot_id: null,
       },
     });
+
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default text', function() {

--- a/ember/tests/integration/components/timeline-events/flight-upload-test.js
+++ b/ember/tests/integration/components/timeline-events/flight-upload-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: FlightUploadTimelineEventComponent', function() {
+describe('Integration | Component | timeline events/flight upload', function() {
   setupComponentTest('timeline-events/flight-upload', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/integration/components/timeline-events/follower-test.js
+++ b/ember/tests/integration/components/timeline-events/follower-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: FollowerTimelineEventComponent', function() {
+describe('Integration | Component | timeline events/follower', function() {
   setupComponentTest('timeline-events/follower', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/integration/components/timeline-events/follower-test.js
+++ b/ember/tests/integration/components/timeline-events/follower-test.js
@@ -21,8 +21,6 @@ describe('Integration: FollowerTimelineEventComponent', function() {
     this.inject.service('intl', { as: 'intl' });
     this.inject.service('account', { as: 'account' });
 
-    this.get('intl').setLocale('en');
-
     this.set('event', {
       time: '2016-06-24T12:34:56Z',
       actor: {
@@ -34,6 +32,8 @@ describe('Integration: FollowerTimelineEventComponent', function() {
         name: 'Jane Doe',
       },
     });
+
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default text', function() {

--- a/ember/tests/integration/components/timeline-events/new-user-test.js
+++ b/ember/tests/integration/components/timeline-events/new-user-test.js
@@ -21,8 +21,6 @@ describe('Integration: NewUserTimelineEventComponent', function() {
     this.inject.service('intl', { as: 'intl' });
     this.inject.service('account', { as: 'account' });
 
-    this.get('intl').setLocale('en');
-
     this.set('event', {
       time: '2016-06-24T12:34:56Z',
       actor: {
@@ -30,6 +28,8 @@ describe('Integration: NewUserTimelineEventComponent', function() {
         name: 'John Doe',
       },
     });
+
+    return this.get('intl').loadAndSetLocale('en');
   });
 
   it('renders default text', function() {

--- a/ember/tests/integration/components/timeline-events/new-user-test.js
+++ b/ember/tests/integration/components/timeline-events/new-user-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
 import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
-import { beforeEach, it, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-import instanceInitializer from '../../../../instance-initializers/ember-intl';
+import instanceInitializer from 'skylines/instance-initializers/ember-intl';
 
-describe('Integration: NewUserTimelineEventComponent', function() {
+describe('Integration | Component | timeline events/new user', function() {
   setupComponentTest('timeline-events/new-user', { integration: true });
 
   beforeEach(function() {

--- a/ember/tests/unit/helpers/initials-test.js
+++ b/ember/tests/unit/helpers/initials-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+
 import { initials } from 'skylines/helpers/initials';
 
 describe('Unit | Helper | initials', function() {

--- a/ember/tests/unit/utils/add-days-test.js
+++ b/ember/tests/unit/utils/add-days-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+
 import addDays from 'skylines/utils/add-days';
 
 describe('addDays', function() {

--- a/ember/tests/unit/utils/parse-query-string-test.js
+++ b/ember/tests/unit/utils/parse-query-string-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+
 import parseQueryString from 'skylines/utils/parse-query-string';
 
 describe('Unit | Utility | parse query string', function() {


### PR DESCRIPTION
see https://github.com/jasonmit/ember-intl/blob/master/docs/asynchronously-loading-translations.md

this removes 200KB from our `app.js` file while adding one additional AJAX request for the requested translation. not sure yet what is worse...