### PR TITLE
CI: Install "phantomjs-prebuilt" globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ cache: pip
 before_install:
   - nvm install 4
   - npm config set spin false
-  - npm install -g bower
-  - npm install phantomjs-prebuilt
+  - npm install -g bower phantomjs-prebuilt
 
 install:
   # Install SkyLines Python dependencies

--- a/ember/.travis.yml
+++ b/ember/.travis.yml
@@ -12,8 +12,7 @@ cache:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - npm install phantomjs-prebuilt
+  - npm install -g bower phantomjs-prebuilt
 
 install:
   - npm install

--- a/ember/app/routes/application.js
+++ b/ember/app/routes/application.js
@@ -4,6 +4,8 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 
 import _availableLocales from '../utils/locales';
 
+const FALLBACK_LOCALE = 'en';
+
 export default Ember.Route.extend(ApplicationRouteMixin, {
   account: Ember.inject.service(),
   ajax: Ember.inject.service(),
@@ -30,7 +32,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
 
     Ember.debug('Requesting locale resolution from server');
     let data = { available: availableLocales.join() };
-    return this.get('ajax').request('/api/locale', { data }).then(it => it.locale || 'en');
+    return this.get('ajax').request('/api/locale', { data })
+      .then(it => it.locale || FALLBACK_LOCALE)
+      .catch(() => FALLBACK_LOCALE);
   },
 
   setupController(controller) {


### PR DESCRIPTION
Otherwise `testem` is no using the `phantomjs` version we installed, but using the global one instead which is v1.9 by default on Travis.