### PR TITLE
Replace deprecated flask extension python imports

### DIFF
--- a/skylines/api/cache.py
+++ b/skylines/api/cache.py
@@ -1,3 +1,3 @@
-from flask.ext.cache import Cache
+from flask_cache import Cache
 
 cache = Cache()

--- a/skylines/api/oauth.py
+++ b/skylines/api/oauth.py
@@ -4,7 +4,7 @@ from functools import wraps
 from itsdangerous import JSONWebSignatureSerializer
 from flask import Blueprint, request, abort, jsonify, current_app
 
-from flask.ext.oauthlib.provider import OAuth2Provider
+from flask_oauthlib.provider import OAuth2Provider
 from flask_oauthlib.provider import OAuth2RequestValidator
 from flask_oauthlib.provider.oauth2 import log
 from flask_oauthlib.utils import decode_base64

--- a/skylines/commands/__init__.py
+++ b/skylines/commands/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
-from flask.ext.script import Manager
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_script import Manager
+from flask_migrate import Migrate, MigrateCommand
 
 from .shell import Shell
 from .server import Server, APIServer

--- a/skylines/commands/aircraft.py
+++ b/skylines/commands/aircraft.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 from skylines.database import db
 from skylines.model import AircraftModel
 

--- a/skylines/commands/celery.py
+++ b/skylines/commands/celery.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 from skylines import create_celery_app
 from skylines.worker.celery import celery
 

--- a/skylines/commands/database.py
+++ b/skylines/commands/database.py
@@ -1,5 +1,5 @@
-from flask.ext.script import Manager, prompt_bool
-from flask.ext.migrate import stamp
+from flask_script import Manager, prompt_bool
+from flask_migrate import stamp
 
 from skylines.database import db
 from tests.data.bootstrap import bootstrap as _bootstrap

--- a/skylines/commands/flights/__init__.py
+++ b/skylines/commands/flights/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from .analysis import Analyze, AnalyzeDelayed
 from .copy_flights import CopyFlights

--- a/skylines/commands/flights/analysis.py
+++ b/skylines/commands/flights/analysis.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from flask import current_app
 from sqlalchemy.orm import joinedload

--- a/skylines/commands/flights/copy_flights.py
+++ b/skylines/commands/flights/copy_flights.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import os
 import shutil

--- a/skylines/commands/flights/delete_flights.py
+++ b/skylines/commands/flights/delete_flights.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from skylines.database import db
 from skylines.model import Flight, IGCFile

--- a/skylines/commands/flights/find_meetings.py
+++ b/skylines/commands/flights/find_meetings.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 from flask import current_app
 from skylines.database import db
 from skylines.model import Flight

--- a/skylines/commands/flights/selector.py
+++ b/skylines/commands/flights/selector.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Option
+from flask_script import Option
 from sqlalchemy import func
 from datetime import datetime
 

--- a/skylines/commands/flights/update_flight_paths.py
+++ b/skylines/commands/flights/update_flight_paths.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from sqlalchemy.orm import joinedload
 from skylines.database import db

--- a/skylines/commands/import_/__init__.py
+++ b/skylines/commands/import_/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from .airspace import AirspaceCommand
 from .dmst_index import DMStIndex

--- a/skylines/commands/import_/airspace.py
+++ b/skylines/commands/import_/airspace.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import re
 import shutil

--- a/skylines/commands/import_/dmst_index.py
+++ b/skylines/commands/import_/dmst_index.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import re
 from skylines.database import db

--- a/skylines/commands/import_/mwp.py
+++ b/skylines/commands/import_/mwp.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import math
 from skylines.database import db

--- a/skylines/commands/import_/srtm.py
+++ b/skylines/commands/import_/srtm.py
@@ -1,5 +1,5 @@
 import sys
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import os
 import subprocess

--- a/skylines/commands/import_/welt2000.py
+++ b/skylines/commands/import_/welt2000.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from skylines.database import db
 from skylines.model import Airport

--- a/skylines/commands/notifications/__init__.py
+++ b/skylines/commands/notifications/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from .mark_all_unread import MarkAllUnread
 

--- a/skylines/commands/notifications/mark_all_unread.py
+++ b/skylines/commands/notifications/mark_all_unread.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command
+from flask_script import Command
 from skylines.database import db
 from skylines.model import Notification
 

--- a/skylines/commands/search.py
+++ b/skylines/commands/search.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from skylines.model import User, Club, Airport
 from skylines.model.search import combined_search_query, escape_tokens

--- a/skylines/commands/server.py
+++ b/skylines/commands/server.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Server as BaseServer
+from flask_script import Server as BaseServer
 from skylines.app import create_combined_app, create_api_app
 
 

--- a/skylines/commands/shell.py
+++ b/skylines/commands/shell.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Shell as BaseShell
+from flask_script import Shell as BaseShell
 
 from flask import current_app
 from skylines import model, database

--- a/skylines/commands/tracking/__init__.py
+++ b/skylines/commands/tracking/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from .clear import Clear
 from .export import Export

--- a/skylines/commands/tracking/clear.py
+++ b/skylines/commands/tracking/clear.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 from skylines.database import db
 from skylines.model import TrackingFix
 

--- a/skylines/commands/tracking/export.py
+++ b/skylines/commands/tracking/export.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import hashlib
 import aerofiles.igc

--- a/skylines/commands/tracking/fill_missing_keys.py
+++ b/skylines/commands/tracking/fill_missing_keys.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command
+from flask_script import Command
 from skylines.database import db
 from skylines.model import User
 

--- a/skylines/commands/tracking/generate.py
+++ b/skylines/commands/tracking/generate.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import sys
 from math import sin

--- a/skylines/commands/tracking/generate_through_daemon.py
+++ b/skylines/commands/tracking/generate_through_daemon.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import sys
 import socket

--- a/skylines/commands/tracking/server.py
+++ b/skylines/commands/tracking/server.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command
+from flask_script import Command
 
 from skylines.app import create_app
 from skylines.tracking.server import TrackingServer

--- a/skylines/commands/tracking/stats.py
+++ b/skylines/commands/tracking/stats.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 from datetime import timedelta
 from itertools import chain

--- a/skylines/commands/users/__init__.py
+++ b/skylines/commands/users/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from .merge import Merge
 

--- a/skylines/commands/users/merge.py
+++ b/skylines/commands/users/merge.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Command, Option
+from flask_script import Command, Option
 
 import sys
 

--- a/skylines/database.py
+++ b/skylines/database.py
@@ -1,4 +1,4 @@
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 
 def query(cls, **kw):


### PR DESCRIPTION
Replace deprecated flask.ext.* python imports with the appropriate flask_* imports.

See https://github.com/pallets/flask/pull/1484 