### PR TITLE
add "noopener" to all external links

### DIFF
--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -175,7 +175,7 @@ export default Ember.Component.extend({
       source: new ol.source.XYZ({
         attributions: [
           new ol.Attribution({
-            html: 'SRTM relief maps from <a target="_blank" ' +
+            html: 'SRTM relief maps from <a target="_blank" rel="noopener" ' +
                 'href="http://maps-for-free.com/">maps-for-free.com</a>',
           }),
         ],
@@ -203,11 +203,11 @@ export default Ember.Component.extend({
         attributions: [
           new ol.Attribution({
             html: '<a href="https://www.mapbox.com/about/maps/"' +
-                ' target="_blank">' +
+                ' target="_blank" rel="noopener">' +
                 '&copy; Mapbox &copy; OpenStreetMap</a> <a' +
                 ' class="mapbox-improve-map"' +
                 ' href="https://www.mapbox.com/map-feedback/"' +
-                ' target="_blank">Improve this map</a>',
+                ' target="_blank" rel="noopener">Improve this map</a>',
           }),
         ],
         url: tile_url,

--- a/ember/app/components/share-button.js
+++ b/ember/app/components/share-button.js
@@ -10,9 +10,9 @@ export default Ember.Component.extend({
 
     let content = `<div style="text-align:center">
       <input value="${url}" type="text" class="form-control" style="margin-bottom:9px">
-      <a href="https://www.facebook.com/share.php?u=${url}" target="_blank" class="btn btn-default btn-xs"><i class="fa fa-facebook"> Share</i></a>
-      <a href="https://plus.google.com/share?url=${url}" target="_blank" class="btn btn-default btn-xs"><i class="fa fa-google-plus"> Share</i></a>
-      <a href="https://twitter.com/share?url=${url}" target="_blank" class="btn btn-default btn-xs"><i class="fa fa-twitter"> Tweet</i></a>
+      <a href="https://www.facebook.com/share.php?u=${url}" target="_blank" rel="noopener" class="btn btn-default btn-xs"><i class="fa fa-facebook"> Share</i></a>
+      <a href="https://plus.google.com/share?url=${url}" target="_blank" rel="noopener" class="btn btn-default btn-xs"><i class="fa fa-google-plus"> Share</i></a>
+      <a href="https://twitter.com/share?url=${url}" target="_blank" rel="noopener" class="btn btn-default btn-xs"><i class="fa fa-twitter"> Tweet</i></a>
     </div>`;
 
     let popover_template = `<div class="popover" style="white-space: nowrap; z-index: 5000;">

--- a/ember/app/templates/club/index.hbs
+++ b/ember/app/templates/club/index.hbs
@@ -16,7 +16,7 @@
             {{#if club.website}}
               <tr>
                 <th>{{t "website"}}</th>
-                <td><a target="_blank" href="{{club.website}}">{{club.website}}</a></td>
+                <td><a target="_blank" rel="noopener" href="{{club.website}}">{{club.website}}</a></td>
               </tr>
             {{/if}}
 

--- a/ember/app/templates/components/search-result-row.hbs
+++ b/ember/app/templates/components/search-result-row.hbs
@@ -28,7 +28,7 @@
     {{link-to result.name "club" result.id}}
 
     {{#if result.website}}
-      <small>- <a href={{result.website}} target="_blank">{{result.website}}</a></small>
+      <small>- <a href={{result.website}} target="_blank" rel="noopener">{{result.website}}</a></small>
     {{/if}}
 
   {{else if (eq result.type "airport")}}

--- a/ember/app/templates/index.hbs
+++ b/ember/app/templates/index.hbs
@@ -5,10 +5,10 @@
         <p class="lead pull-left">{{t "about.welcome"}}</p>
 
         <div class="btn-group social-buttons pull-right visible-md visible-lg">
-          <a href="https://www.facebook.com/skylines.project" class="btn btn-default" target="_blank">{{fa-icon "facebook-square"}}</a>
-          <a href="https://twitter.com/skylinesproject" class="btn btn-default" target="_blank">{{fa-icon "twitter"}}</a>
-          <a href="https://plus.google.com/114462603028839635814" class="btn btn-default" target="_blank">{{fa-icon "google-plus"}}</a>
-          <a href="https://github.com/skylines-project/skylines" class="btn btn-default" target="_blank">{{fa-icon "github-alt"}}</a>
+          <a href="https://www.facebook.com/skylines.project" class="btn btn-default" target="_blank" rel="noopener">{{fa-icon "facebook-square"}}</a>
+          <a href="https://twitter.com/skylinesproject" class="btn btn-default" target="_blank" rel="noopener">{{fa-icon "twitter"}}</a>
+          <a href="https://plus.google.com/114462603028839635814" class="btn btn-default" target="_blank" rel="noopener">{{fa-icon "google-plus"}}</a>
+          <a href="https://github.com/skylines-project/skylines" class="btn btn-default" target="_blank" rel="noopener">{{fa-icon "github-alt"}}</a>
         </div>
       </div>
     </div>

--- a/ember/app/templates/tracking/info.hbs
+++ b/ember/app/templates/tracking/info.hbs
@@ -13,13 +13,13 @@
         <li>
           <b>XCSoar:</b><br/>
           {{format-html-message "tracking.xcsoar-description" release=(html-safe "<a href=\"http://www.xcsoar.org/download/latest.html\">XCSoar 6.4</a>")}}
-          (<a href="https://play.google.com/store/apps/details?id=org.xcsoar" target="_blank">Google Play</a>).
+          (<a href="https://play.google.com/store/apps/details?id=org.xcsoar" target="_blank" rel="noopener">Google Play</a>).
           {{t "tracking.instructions-below"}}
         </li>
         <li>
           <b>Gaggle:</b><br/>
           {{t "tracking.available-in-gaggle"}}
-          (<a href="https://play.google.com/store/apps/details?id=com.geeksville.gaggle" target="_blank">Google Play</a>)
+          (<a href="https://play.google.com/store/apps/details?id=com.geeksville.gaggle" target="_blank" rel="noopener">Google Play</a>)
         </li>
         <li>
           <b>{{t "tracking.lt24-clients"}}:</b><br/>


### PR DESCRIPTION
This adds rel="noopener" to all external opened links with target=_"blank", fixes #625

see [https://developers.google.com/web/tools/lighthouse/audits/noopener](https://developers.google.com/web/tools/lighthouse/audits/noopener)