### PR TITLE
Serveral styling fixes for the flight details page

### DIFF
--- a/ember/app/components/flight-page.js
+++ b/ember/app/components/flight-page.js
@@ -43,12 +43,17 @@ export default Ember.Component.extend({
 
     let sidebar = this.$('#sidebar').sidebar();
 
-    this.$('#barogram_panel').resize(() => {
-      let height = this.$('#barogram_panel').height() + 10;
+    let resize = () => {
+      let $barogramPanel = this.$('#barogram_panel');
+      let bottom = Number($barogramPanel.css('bottom').replace('px', ''));
+      let height = $barogramPanel.height() + bottom;
       sidebar.css('bottom', height);
       this.$('.ol-scale-line').css('bottom', height);
       this.$('.ol-attribution').css('bottom', height);
-    });
+    };
+
+    resize();
+    this.$('#barogram_panel').resize(resize);
 
     if (window.location.hash &&
       sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {

--- a/ember/app/components/flight-page.js
+++ b/ember/app/components/flight-page.js
@@ -58,6 +58,8 @@ export default Ember.Component.extend({
     if (window.location.hash &&
       sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {
       sidebar.open(window.location.hash.substring(1));
+    } else if (window.innerWidth >= 768) {
+      sidebar.open('tab-overview');
     }
 
     let [primaryId, ...otherIds] = this.get('ids');

--- a/ember/app/components/tracking-page.js
+++ b/ember/app/components/tracking-page.js
@@ -40,12 +40,17 @@ export default Ember.Component.extend({
 
     let sidebar = this.$('#sidebar').sidebar();
 
-    this.$('#barogram_panel').resize(() => {
-      let height = this.$('#barogram_panel').height() + 10;
+    let resize = () => {
+      let $barogramPanel = this.$('#barogram_panel');
+      let bottom = Number($barogramPanel.css('bottom').replace('px', ''));
+      let height = $barogramPanel.height() + bottom;
       sidebar.css('bottom', height);
       this.$('.ol-scale-line').css('bottom', height);
       this.$('.ol-attribution').css('bottom', height);
-    });
+    };
+
+    resize();
+    this.$('#barogram_panel').resize(resize);
 
     if (window.location.hash &&
       sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {

--- a/ember/app/components/tracking-page.js
+++ b/ember/app/components/tracking-page.js
@@ -55,6 +55,8 @@ export default Ember.Component.extend({
     if (window.location.hash &&
       sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {
       sidebar.open(window.location.hash.substring(1));
+    } else if (window.innerWidth >= 768 && flights.length > 1) {
+      sidebar.open('tab-overview');
     }
 
     let map = window.flightMap.get('map');

--- a/ember/app/styles/_bootstrap-theme-skylines.scss
+++ b/ember/app/styles/_bootstrap-theme-skylines.scss
@@ -196,14 +196,6 @@ ul.list-with-dividers li[class*="col"] {
   list-style: none;
 }
 
-.alert-floating {
-  position: relative;
-  top: 60px;
-  margin-left: auto;
-  margin-right: auto;
-  width: 50%;
-}
-
 .tooltip {
   /*
    * The tooltips in the flight table are broken otherwise because

--- a/ember/app/styles/_ol3-sidebar.scss
+++ b/ember/app/styles/_ol3-sidebar.scss
@@ -5,7 +5,7 @@
   bottom: 0;
   width: 100%;
   overflow: hidden;
-  z-index: 2000; }
+  z-index: 1900; }
   .sidebar.collapsed {
     width: 40px; }
   @media (min-width: 768px) {

--- a/ember/app/templates/components/flight-page.hbs
+++ b/ember/app/templates/components/flight-page.hbs
@@ -1,7 +1,7 @@
-<div id="sidebar" class="sidebar">
+<div id="sidebar" class="sidebar collapsed">
   <!-- Nav tabs -->
   <ul class="sidebar-tabs" role="tablist">
-    <li class="active">
+    <li>
       <a href="#tab-overview" title="{{t "overview"}}" role="tab">
         {{fa-icon "info" size="lg"}}
       </a>
@@ -38,7 +38,7 @@
   </ul>
   <!-- Tab panes -->
   <div class="sidebar-content">
-    <div class="sidebar-pane active" id="tab-overview">
+    <div class="sidebar-pane" id="tab-overview">
       <h3>{{t "overview"}}{{share-button}}</h3>
       <div class="sidebar-pane-content">
         {{flight-details-table flight=flight transitionTo=transitionTo}}

--- a/ember/app/templates/components/tracking-page.hbs
+++ b/ember/app/templates/components/tracking-page.hbs
@@ -1,8 +1,8 @@
 {{#if flights}}
-  <div id="sidebar" class="sidebar">
+  <div id="sidebar" class="sidebar collapsed">
     <!-- Nav tabs -->
     <ul class="sidebar-tabs" role="tablist">
-      <li class="active">
+      <li>
         <a href="#tab-overview" title="{{t "overview"}}" role="tab">
           {{fa-icon "info" size="lg"}}
         </a>
@@ -10,7 +10,7 @@
     </ul>
     <!-- Tab panes -->
     <div class="sidebar-content">
-      <div class="sidebar-pane active" id="tab-overview">
+      <div class="sidebar-pane" id="tab-overview">
         <h3>{{t "overview"}}</h3>
         <div class="sidebar-pane-content">
           {{tracking-pilots-list pilots=pilots}}


### PR DESCRIPTION
- The main menu is no longer hiding behind the sidebar
- The sidebar height is calculated properly on small devices
- The sidebar is collapsed by default on small screens or when tracking only a single pilot