### PR TITLE
CI: Use "trusty" dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+dist: trusty
+sudo: false
+
 language: python
 
 python:
   - 2.7
 
-sudo: false
+addons:
+  postgresql: "9.5"
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.3
 
 services:
   - postgresql


### PR DESCRIPTION
... and postgresql 9.5 with PostGIS 2.3

This should hopefully fix the currently failing CI builds