### PR TITLE
wip: show (last) position in live tracking overview panel

### DIFF
--- a/ember/app/templates/components/tracking-page.hbs
+++ b/ember/app/templates/components/tracking-page.hbs
@@ -13,7 +13,9 @@
       <div class="sidebar-pane" id="tab-overview">
         <h3>{{t "overview"}}</h3>
         <div class="sidebar-pane-content">
-          {{tracking-pilots-list pilots=pilots}}
+          {{#if fixCalc.fixes.[0].coordinate}}
+            {{tracking-pilots-list pilots=pilots lat=fixCalc.fixes.[0].lat lon=fixCalc.fixes.[0].lon}}
+          {{/if}}
         </div>
       </div>
     </div>

--- a/ember/app/templates/components/tracking-pilots-list.hbs
+++ b/ember/app/templates/components/tracking-pilots-list.hbs
@@ -14,6 +14,12 @@
         </tr>
       {{/if}}
 
+      <tr>
+        <th>{{t "last-position"}}</th>
+        <td>{{lat}}</td>
+        <td>{{lon}}</td>
+      </tr>
+
       {{#if (gt pilot.trackingDelay 0)}}
         <tr>
           <th>{{t "delay"}}</th>

--- a/ember/translations/de.yaml
+++ b/ember/translations/de.yaml
@@ -95,6 +95,7 @@ landing-time: Landezeit
 last-12-months: Letzte 12 Monate
 last-fix: Letzter Kontakt
 last-name: Nachname
+last-position: Letzte Position
 latest: Letzter
 n-avg-distance-per-flight: '{distance} pro Flug'
 leg-statistics: Schenkel-Statistik

--- a/ember/translations/en.yaml
+++ b/ember/translations/en.yaml
@@ -96,6 +96,7 @@ landing-time: Landing time
 last-12-months: Last 12 Months
 last-fix: Last Fix
 last-name: Last name
+last-position: Last position
 latest: Latest
 n-avg-distance-per-flight: avg. {distance} per flight
 leg-statistics: Leg Statistics


### PR DESCRIPTION
The position used by open layers is displayed, but i can't figure out, how to transform it back to a common coordinate projection like used by google maps. 
I am currently figuring out, how to get the location like provided by [/api/live](https://skylines.aero/api/live), but this seems to require changes to the api or an additional api request in the tracking-page ember component. Both would not be smart, so please let me know, if you have a smart solution for this.

Fixes #250