### PR TITLE
testem: Use `--no-sandbox` on TravisCI

### DIFF
--- a/ember/testem.js
+++ b/ember/testem.js
@@ -13,10 +13,13 @@ module.exports = {
   ],
   browser_args: {
     Chrome: [
+      // --no-sandbox is needed when running Chrome inside a container
+      process.env.TRAVIS ? '--no-sandbox' : null,
+
       '--disable-gpu',
       '--headless',
       '--remote-debugging-port=9222',
       '--window-size=1440,900',
-    ],
+    ].filter(Boolean),
   },
 };


### PR DESCRIPTION
This should fix the CI builds that broke due to https://github.com/travis-ci/travis-ci/issues/8836