### PR TITLE
Revert "Update `ember-cookies` to 0.1.2"

### DIFF
--- a/ember/package.json
+++ b/ember/package.json
@@ -48,7 +48,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-uglify": "^2.0.0",
     "ember-concurrency": "^0.8.12",
-    "ember-cookies": "^0.1.2",
+    "ember-cookies": "^0.0.13",
     "ember-cp-validations": "^3.5.1",
     "ember-font-awesome": "^3.1.1",
     "ember-href-to": "^1.13.0",

--- a/ember/yarn.lock
+++ b/ember/yarn.lock
@@ -3232,7 +3232,14 @@ ember-concurrency@^0.8.12:
     ember-getowner-polyfill "^2.0.0"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-cookies@^0.1.0, ember-cookies@^0.1.2:
+ember-cookies@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.0.13.tgz#18350df766240793d46744e4ee5c9a55ae6b4e0a"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-getowner-polyfill "^1.2.2"
+
+ember-cookies@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.1.2.tgz#f652efcb289534cdc1425832ed3c77aeb432ef72"
   dependencies:


### PR DESCRIPTION
This reverts commit b10519b9a67efbce0dbfc8c2fa66949d479c17bf. 

Main issue seems to be https://github.com/simplabs/ember-cookies/issues/145