### PR TITLE
Add `map-settings` service

### DIFF
--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -6,16 +6,14 @@ import { tag } from 'ember-awesome-macros';
 import { htmlSafe } from 'ember-awesome-macros/string';
 
 import config from '../config/environment';
-import parseQueryString from '../utils/parse-query-string';
 
 export default Component.extend({
-  cookies: service(),
+  mapSettings: service(),
 
   attributeBindings: ['style'],
 
   width: '100%',
   height: '100%',
-  baseLayer: null,
 
   style: htmlSafe(tag`width: ${'width'}; height: ${'height'}; position: relative`),
 
@@ -69,13 +67,9 @@ export default Component.extend({
     this.addMapboxLayer();
     this.addEmptyLayer();
 
-    let query = parseQueryString(window.location.search);
-    this.set('baseLayer', query.baselayer);
-    this.set('overlayLayers', query.overlays);
-
-    let cookies = this.get('cookies');
-    this.setBaseLayer(this.get('baseLayer') || cookies.read('base_layer') || 'OpenStreetMap');
-    this.setOverlayLayers(this.get('overlayLayers') || cookies.read('overlay_layers') || 'Airspace');
+    let mapSettings = this.get('mapSettings');
+    this.setBaseLayer(mapSettings.get('baseLayer'));
+    this.setOverlayLayers(mapSettings.get('overlayLayers'));
   },
 
   didInsertElement() {
@@ -109,12 +103,6 @@ export default Component.extend({
   },
 
   setOverlayLayers(overlay_layers) {
-    if (!overlay_layers) {
-      return;
-    }
-
-    overlay_layers = overlay_layers.split(';');
-
     // Cycle through the overlay layers to find a match
     this.get('map').getLayers().forEach(layer => {
       if (layer.get('base_layer') || !layer.get('display_in_layer_switcher')) {

--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -1,5 +1,8 @@
 import { inject as service } from '@ember/service';
+import { observer } from '@ember/object';
 import Component from '@ember/component';
+import { once } from '@ember/runloop';
+
 import $ from 'jquery';
 import ol from 'openlayers';
 import { tag } from 'ember-awesome-macros';
@@ -16,6 +19,10 @@ export default Component.extend({
   height: '100%',
 
   style: htmlSafe(tag`width: ${'width'}; height: ${'height'}; position: relative`),
+
+  mapSettingsObserver: observer('mapSettings.baseLayer', 'mapSettings.overlayLayers.[]', function() {
+    once(this, 'updateLayerVisibilities');
+  }),
 
   init() {
     this._super(...arguments);

--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -67,9 +67,7 @@ export default Component.extend({
     this.addMapboxLayer();
     this.addEmptyLayer();
 
-    let mapSettings = this.get('mapSettings');
-    this.setBaseLayer(mapSettings.get('baseLayer'));
-    this.setOverlayLayers(mapSettings.get('overlayLayers'));
+    this.updateLayerVisibilities();
   },
 
   didInsertElement() {
@@ -78,6 +76,12 @@ export default Component.extend({
     if (map) {
       map.setTarget(this.elementId);
     }
+  },
+
+  updateLayerVisibilities() {
+    let mapSettings = this.get('mapSettings');
+    this.setBaseLayer(mapSettings.get('baseLayer'));
+    this.setOverlayLayers(mapSettings.get('overlayLayers'));
   },
 
   setBaseLayer(base_layer) {

--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -80,22 +80,16 @@ export default Component.extend({
 
   updateLayerVisibilities() {
     let mapSettings = this.get('mapSettings');
-    this.setBaseLayer(mapSettings.get('baseLayer'));
-    this.setOverlayLayers(mapSettings.get('overlayLayers'));
-  },
-
-  setBaseLayer(base_layer) {
-    if (!base_layer) {
-      return;
-    }
+    let baseLayer = mapSettings.get('baseLayer');
+    let overlayLayers = mapSettings.get('overlayLayers');
 
     let fallback = false;
     let map = this.get('map');
 
     map.getLayers().forEach(layer => {
       if (layer.get('base_layer')) {
-        layer.setVisible(layer.get('name') === base_layer);
-        fallback = fallback || layer.get('name') === base_layer;
+        layer.setVisible(layer.get('name') === baseLayer);
+        fallback = fallback || layer.get('name') === baseLayer;
       }
     });
 
@@ -104,16 +98,14 @@ export default Component.extend({
         return e.get('name') === 'OpenStreetMap';
       })[0].setVisible(true);
     }
-  },
 
-  setOverlayLayers(overlay_layers) {
     // Cycle through the overlay layers to find a match
-    this.get('map').getLayers().forEach(layer => {
+    map.getLayers().forEach(layer => {
       if (layer.get('base_layer') || !layer.get('display_in_layer_switcher')) {
         return;
       }
 
-      layer.setVisible($.inArray(layer.get('name'), overlay_layers) !== -1);
+      layer.setVisible($.inArray(layer.get('name'), overlayLayers) !== -1);
     });
   },
 

--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -86,7 +86,9 @@ export default Component.extend({
     let fallback = false;
     let map = this.get('map');
 
-    map.getLayers().forEach(layer => {
+    let layers = map.getLayers().getArray().filter(layer => layer.get('display_in_layer_switcher'));
+
+    layers.forEach(layer => {
       if (layer.get('base_layer')) {
         layer.setVisible(layer.get('name') === baseLayer);
         fallback = fallback || layer.get('name') === baseLayer;
@@ -94,14 +96,14 @@ export default Component.extend({
     });
 
     if (!fallback) {
-      map.getLayers().getArray().filter(function(e) {
+      layers.filter(function(e) {
         return e.get('name') === 'OpenStreetMap';
       })[0].setVisible(true);
     }
 
     // Cycle through the overlay layers to find a match
-    map.getLayers().forEach(layer => {
-      if (layer.get('base_layer') || !layer.get('display_in_layer_switcher')) {
+    layers.forEach(layer => {
+      if (layer.get('base_layer')) {
         return;
       }
 

--- a/ember/app/components/base-map.js
+++ b/ember/app/components/base-map.js
@@ -80,34 +80,24 @@ export default Component.extend({
 
   updateLayerVisibilities() {
     let mapSettings = this.get('mapSettings');
-    let baseLayer = mapSettings.get('baseLayer');
-    let overlayLayers = mapSettings.get('overlayLayers');
+    let baseLayerNames = mapSettings.get('baseLayer');
+    let overlayLayerNames = mapSettings.get('overlayLayers');
 
-    let fallback = false;
-    let map = this.get('map');
+    let layers = this.get('map').getLayers().getArray()
+      .filter(layer => layer.get('display_in_layer_switcher'));
 
-    let layers = map.getLayers().getArray().filter(layer => layer.get('display_in_layer_switcher'));
-
-    layers.forEach(layer => {
-      if (layer.get('base_layer')) {
-        layer.setVisible(layer.get('name') === baseLayer);
-        fallback = fallback || layer.get('name') === baseLayer;
-      }
+    let baseLayers = layers.filter(layer => layer.get('base_layer'));
+    baseLayers.forEach(layer => {
+      layer.setVisible(layer.get('name') === baseLayerNames);
     });
 
-    if (!fallback) {
-      layers.filter(function(e) {
-        return e.get('name') === 'OpenStreetMap';
-      })[0].setVisible(true);
+    if (!baseLayers.find(layer => layer.get('name') === baseLayerNames)) {
+      baseLayers.find(layer => layer.get('name') === 'OpenStreetMap').setVisible(true);
     }
 
-    // Cycle through the overlay layers to find a match
-    layers.forEach(layer => {
-      if (layer.get('base_layer')) {
-        return;
-      }
-
-      layer.setVisible($.inArray(layer.get('name'), overlayLayers) !== -1);
+    let overlayLayers = layers.filter(layer => !layer.get('base_layer'));
+    overlayLayers.forEach(layer => {
+      layer.setVisible(overlayLayerNames.includes(layer.get('name')));
     });
   },
 

--- a/ember/app/components/layer-switcher.js
+++ b/ember/app/components/layer-switcher.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import $ from 'jquery';
 
 export default Component.extend({
-  cookies: service(),
+  mapSettings: service(),
 
   classNames: ['GraphicLayerSwitcher', 'ol-unselectable'],
 
@@ -37,18 +37,23 @@ export default Component.extend({
     },
 
     select(layer) {
+      let mapSettings = this.get('mapSettings');
+
       if (layer.isBaseLayer) {
+        mapSettings.setBaseLayer(layer.name);
+
         this.get('map').getLayers().getArray()
           .filter(it => it.get('base_layer'))
           .forEach(it => it.setVisible(it.get('id') === layer.id));
 
       } else {
+        mapSettings.toggleOverlayLayer(layer.name);
+
         this.get('map').getLayers().getArray()
           .filter(it => (it.get('id') === layer.id))
           .forEach(it => it.setVisible(!it.getVisible()));
       }
 
-      this.setLayerCookies();
       this.updateLayers();
     },
   },
@@ -66,19 +71,5 @@ export default Component.extend({
 
     this.set('baseLayers', layers.filter(layer => layer.isBaseLayer));
     this.set('overlayLayers', layers.filter(layer => !layer.isBaseLayer));
-  },
-
-  setLayerCookies() {
-    let cookies = this.get('cookies');
-    let layers = this.get('map').getLayers().getArray();
-
-    let baseLayer = layers.filter(it => (it.get('base_layer') && it.getVisible()))[0];
-    cookies.write('base_layer', baseLayer.get('name'), { path: '/', expires: new Date('2099-12-31') });
-
-    let overlayLayers = layers.filter(it => (!it.get('base_layer') && it.getVisible()))
-      .map(it => it.get('name'))
-      .join(';');
-
-    cookies.write('overlay_layers', overlayLayers, { path: '/', expires: new Date('2099-12-31') });
   },
 });

--- a/ember/app/components/layer-switcher.js
+++ b/ember/app/components/layer-switcher.js
@@ -59,12 +59,14 @@ export default Component.extend({
   },
 
   updateLayers() {
+    let mapSettings = this.get('mapSettings');
+
     let layers = this.get('map').getLayers().getArray()
       .filter(layer => layer.get('display_in_layer_switcher'))
       .map(layer => {
         let id = layer.get('id');
         let name = layer.get('name');
-        let visible = layer.getVisible();
+        let visible = mapSettings.isLayerVisible(name);
         let isBaseLayer = layer.get('base_layer');
         return { id, name, visible, isBaseLayer };
       });

--- a/ember/app/components/layer-switcher.js
+++ b/ember/app/components/layer-switcher.js
@@ -41,17 +41,8 @@ export default Component.extend({
 
       if (layer.isBaseLayer) {
         mapSettings.setBaseLayer(layer.name);
-
-        this.get('map').getLayers().getArray()
-          .filter(it => it.get('base_layer'))
-          .forEach(it => it.setVisible(it.get('id') === layer.id));
-
       } else {
         mapSettings.toggleOverlayLayer(layer.name);
-
-        this.get('map').getLayers().getArray()
-          .filter(it => (it.get('id') === layer.id))
-          .forEach(it => it.setVisible(!it.getVisible()));
       }
 
       this.updateLayers();

--- a/ember/app/services/map-settings.js
+++ b/ember/app/services/map-settings.js
@@ -49,6 +49,10 @@ export default Service.extend({
     }
   },
 
+  isLayerVisible(layer) {
+    return this.get('baseLayer') === layer || this.get('overlayLayers').includes(layer);
+  },
+
   setBaseLayer(baseLayer) {
     this.set('_baseLayer', baseLayer);
     this.get('cookies').write(BASE_LAYER_COOKIE_KEY, baseLayer, { path: '/', expires: new Date('2099-12-31') });

--- a/ember/app/services/map-settings.js
+++ b/ember/app/services/map-settings.js
@@ -1,0 +1,60 @@
+import Service, { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+
+import { or } from 'ember-awesome-macros';
+
+import parseQueryString from 'skylines/utils/parse-query-string';
+
+export const BASE_LAYER_COOKIE_KEY = 'base_layer';
+export const OVERLAY_LAYERS_COOKIE_KEY = 'overlay_layers';
+
+export default Service.extend({
+  cookies: service(),
+  router: service(),
+
+  _baseLayer: 'OpenStreetMap',
+  // _overlayLayers: ['Airspace'],
+
+  baseLayer: or('_query.baselayer', '_baseLayer'),
+  overlayLayers: computed('_query.overlays', '_overlayLayers', function() {
+    let queryOverlays = this.get('_query.overlays');
+    if (queryOverlays === undefined) {
+      return this.get('_overlayLayers');
+    } else if (queryOverlays === '') {
+      return [];
+    } else {
+      return queryOverlays.split(';');
+    }
+  }),
+
+  _query: computed('router.currentURL', function() {
+    let currentURL = this.get('router.currentURL');
+    let queryString = extractQueryString(currentURL);
+    return parseQueryString(queryString);
+  }),
+
+  init() {
+    this._super(...arguments);
+    this.set('_overlayLayers', ['Airspace']);
+
+    let cookies = this.get('cookies');
+    let cookieBaseLayer = cookies.read(BASE_LAYER_COOKIE_KEY);
+    if (cookieBaseLayer) {
+      this.set('_baseLayer', cookieBaseLayer);
+    }
+
+    let cookieOverlayLayers = cookies.read(OVERLAY_LAYERS_COOKIE_KEY);
+    if (cookieOverlayLayers !== undefined) {
+      this.set('_overlayLayers', cookieOverlayLayers === '' ? [] : cookieOverlayLayers.split(';'));
+    }
+  },
+});
+
+function extractQueryString(url) {
+  let qIndex = url.indexOf('?');
+  if (qIndex === -1) {
+    return null;
+  }
+
+  return url.slice(qIndex + 1);
+}

--- a/ember/app/services/map-settings.js
+++ b/ember/app/services/map-settings.js
@@ -53,6 +53,17 @@ export default Service.extend({
     this.set('_baseLayer', baseLayer);
     this.get('cookies').write(BASE_LAYER_COOKIE_KEY, baseLayer, { path: '/', expires: new Date('2099-12-31') });
   },
+
+  toggleOverlayLayer(overlayLayer) {
+    let overlayLayers = this.get('overlayLayers');
+    if (overlayLayers.includes(overlayLayer)) {
+      overlayLayers.removeObject(overlayLayer);
+    } else {
+      overlayLayers.pushObject(overlayLayer);
+    }
+
+    this.get('cookies').write(OVERLAY_LAYERS_COOKIE_KEY, overlayLayers.join(';'), { path: '/', expires: new Date('2099-12-31') });
+  },
 });
 
 function extractQueryString(url) {

--- a/ember/app/services/map-settings.js
+++ b/ember/app/services/map-settings.js
@@ -48,6 +48,11 @@ export default Service.extend({
       this.set('_overlayLayers', cookieOverlayLayers === '' ? [] : cookieOverlayLayers.split(';'));
     }
   },
+
+  setBaseLayer(baseLayer) {
+    this.set('_baseLayer', baseLayer);
+    this.get('cookies').write(BASE_LAYER_COOKIE_KEY, baseLayer, { path: '/', expires: new Date('2099-12-31') });
+  },
 });
 
 function extractQueryString(url) {

--- a/ember/tests/unit/services/map-settings-test.js
+++ b/ember/tests/unit/services/map-settings-test.js
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+import Service from '@ember/service';
+import { BASE_LAYER_COOKIE_KEY, OVERLAY_LAYERS_COOKIE_KEY } from 'skylines/services/map-settings';
+
+describe('Unit | Service | map-settings', function() {
+  setupTest('service:map-settings', { integration: true });
+
+  beforeEach(function() {
+    this.register('service:router', Service.extend({
+      currentURL: '/'
+    }));
+
+    this.register('service:cookies', Service.extend({
+      read(key) {
+        if (key === BASE_LAYER_COOKIE_KEY) {
+          return 'Foo';
+        } else if (key === OVERLAY_LAYERS_COOKIE_KEY) {
+          return 'Bar;Baz';
+        }
+      },
+    }));
+  });
+
+  it('defaults to "OpenStreetMap" and "Airspace"', function() {
+    this.register('service:cookies', Service.extend({
+      read() {},
+    }));
+
+    let service = this.subject();
+    expect(service.get('baseLayer')).to.equal('OpenStreetMap');
+    expect(service.get('overlayLayers')).to.deep.equal(['Airspace']);
+  });
+
+  it('reads layers from cookies', function() {
+    let service = this.subject();
+    expect(service.get('baseLayer')).to.equal('Foo');
+    expect(service.get('overlayLayers')).to.deep.equal(['Bar', 'Baz']);
+  });
+
+  it('handles empty overlays cookie correctly', function() {
+    this.register('service:cookies', Service.extend({
+      read(key) {
+        if (key === OVERLAY_LAYERS_COOKIE_KEY) {
+          return '';
+        }
+      },
+    }));
+
+    let service = this.subject();
+    expect(service.get('overlayLayers')).to.deep.equal([]);
+  });
+
+  it('prioritizes layers from query params', function() {
+    let router = this.container.lookup('service:router');
+
+    router.set('currentURL', '/flights/17537?baselayer=alternate&overlays=foo;bar');
+
+    let service = this.subject();
+    expect(service.get('baseLayer')).to.equal('alternate');
+    expect(service.get('overlayLayers')).to.deep.equal(['foo', 'bar']);
+
+    router.set('currentURL', '/flights/17537');
+
+    expect(service.get('baseLayer')).to.equal('Foo');
+    expect(service.get('overlayLayers')).to.deep.equal(['Bar', 'Baz']);
+  });
+
+  it('handles empty overlays query param correctly', function() {
+    let router = this.container.lookup('service:router');
+    router.set('currentURL', '/flights/17537?baselayer=alternate&overlays=');
+
+    let service = this.subject();
+    expect(service.get('overlayLayers')).to.deep.equal([]);
+  });
+});

--- a/ember/tests/unit/services/map-settings-test.js
+++ b/ember/tests/unit/services/map-settings-test.js
@@ -76,6 +76,14 @@ describe('Unit | Service | map-settings', function() {
     expect(service.get('overlayLayers')).to.deep.equal([]);
   });
 
+  it('isLayerVisible() returns true/false if layer is base layer or enabled overlay layer', function() {
+    let service = this.subject();
+    expect(service.isLayerVisible('Foo')).to.be.true;
+    expect(service.isLayerVisible('Bar')).to.be.true;
+    expect(service.isLayerVisible('Baz')).to.be.true;
+    expect(service.isLayerVisible('Qux')).to.be.false;
+  });
+
   it('setBaseLayer() changes the "baseLayer" and persists it to the cookie', function() {
     let writeWasCalled = false;
     this.register('service:cookies', Service.extend({

--- a/ember/tests/unit/services/map-settings-test.js
+++ b/ember/tests/unit/services/map-settings-test.js
@@ -75,4 +75,23 @@ describe('Unit | Service | map-settings', function() {
     let service = this.subject();
     expect(service.get('overlayLayers')).to.deep.equal([]);
   });
+
+  it('setBaseLayer() changes the "baseLayer" and persists it to the cookie', function() {
+    let writeWasCalled = false;
+    this.register('service:cookies', Service.extend({
+      read() {},
+      write(key, value) {
+        expect(key).to.equal(BASE_LAYER_COOKIE_KEY);
+        expect(value).to.equal('foo');
+        writeWasCalled = true;
+      },
+    }));
+
+    let service = this.subject();
+    expect(service.get('baseLayer')).to.equal('OpenStreetMap');
+
+    service.setBaseLayer('foo');
+    expect(service.get('baseLayer')).to.equal('foo');
+    expect(writeWasCalled).to.be.true;
+  });
 });

--- a/ember/tests/unit/services/map-settings-test.js
+++ b/ember/tests/unit/services/map-settings-test.js
@@ -94,4 +94,42 @@ describe('Unit | Service | map-settings', function() {
     expect(service.get('baseLayer')).to.equal('foo');
     expect(writeWasCalled).to.be.true;
   });
+
+  it('toggleOverlayLayer() adds to the existing "overlayLayers" and persists it to the cookie', function() {
+    let writeWasCalled = false;
+    this.register('service:cookies', Service.extend({
+      read() {},
+      write(key, value) {
+        expect(key).to.equal(OVERLAY_LAYERS_COOKIE_KEY);
+        expect(value).to.equal('Airspace;foo');
+        writeWasCalled = true;
+      },
+    }));
+
+    let service = this.subject();
+    expect(service.get('overlayLayers')).to.deep.equal(['Airspace']);
+
+    service.toggleOverlayLayer('foo');
+    expect(service.get('overlayLayers')).to.deep.equal(['Airspace', 'foo']);
+    expect(writeWasCalled).to.be.true;
+  });
+
+  it('toggleOverlayLayer() removes from the existing "overlayLayers" and persists it to the cookie', function() {
+    let writeWasCalled = false;
+    this.register('service:cookies', Service.extend({
+      read() {},
+      write(key, value) {
+        expect(key).to.equal(OVERLAY_LAYERS_COOKIE_KEY);
+        expect(value).to.equal('');
+        writeWasCalled = true;
+      },
+    }));
+
+    let service = this.subject();
+    expect(service.get('overlayLayers')).to.deep.equal(['Airspace']);
+
+    service.toggleOverlayLayer('Airspace');
+    expect(service.get('overlayLayers')).to.deep.equal([]);
+    expect(writeWasCalled).to.be.true;
+  });
 });


### PR DESCRIPTION
This PR introduces a `map-settings` service that is responsible for managing and persisting which layers a user has selected from the layer switcher.