### PR TITLE
Update `xcsoar` to v0.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'crc16==0.1.1',
         'pytz',
         'celery[redis]>=3.1,<3.2',
-        'xcsoar==0.5',
+        'xcsoar==0.6.1',
         'aerofiles==0.1.1',
         'enum34==1.0',
         'pyproj==1.9.3',


### PR DESCRIPTION
v0.6.1 has prebuilt wheels and support for Python 3 🎉 