### PR TITLE
Remove obsolete `raven-js` bower dependency

### DIFF
--- a/ember/bower.json
+++ b/ember/bower.json
@@ -2,7 +2,6 @@
   "name": "skylines",
   "dependencies": {
     "remarkable": "^1.6.2",
-    "raven-js": "^3.15.0",
     "Flot": "flot#0.8.3",
     "flot-marks": "https://github.com/TobiasLohner/flot-marks.git#f09ded70f5a229a38ba0b9cfa92dbb448ca4daaf",
     "jquery": "1.10.2",


### PR DESCRIPTION
forgot that in #737 🤷‍♂️ 