### PR TITLE
Fix MapServer configuration

### DIFF
--- a/mapserver/airports/airports.map
+++ b/mapserver/airports/airports.map
@@ -5,9 +5,11 @@ LAYER
   TYPE POINT
   CONNECTIONTYPE POSTGIS
   CONNECTION "dbname=skylines"
-  DATA "location_wkt from (SELECT id, location_wkt, name, runway_len, type, surface,
-       (-runway_dir) as runway_dir, valid_until from airports) as foo using unique id"
-  FILTER "valid_until < now() at time zone 'utc'"
+  DATA "location_wkt from (
+          SELECT id, location_wkt, name, runway_len, type, surface, (-runway_dir) as runway_dir, valid_until
+          FROM airports
+          WHERE valid_until < now() at time zone 'utc'
+        ) as foo using unique id using srid=4326"
   LABELITEM "name"
 
   PROJECTION
@@ -74,9 +76,11 @@ LAYER
   TYPE POINT
   CONNECTIONTYPE POSTGIS
   CONNECTION "dbname=skylines"
-  DATA "location_wkt from (SELECT id, location_wkt, name, runway_len, type, surface,
-        (-runway_dir) as runway_dir, valid_until from airports) as foo using unique id"
-  FILTER "valid_until >= now() at time zone 'utc' or valid_until is NULL"
+  DATA "location_wkt from (
+          SELECT id, location_wkt, name, runway_len, type, surface, (-runway_dir) as runway_dir, valid_until
+          FROM airports
+          WHERE valid_until >= now() at time zone 'utc' or valid_until is NULL
+        ) as foo using unique id using srid=4326"
   LABELITEM "name"
 
   PROJECTION

--- a/mapserver/airports/airports.map
+++ b/mapserver/airports/airports.map
@@ -64,7 +64,7 @@ LAYER
     END
   END
 
-  SYMBOLSCALEDENOM 6931575 #exactly zoom level 6
+  # SYMBOLSCALEDENOM 6931575 #exactly zoom level 6
 
 END
 
@@ -168,7 +168,7 @@ LAYER
     END
   END
 
-  SYMBOLSCALEDENOM 6931575 #exactly zoom level 6
+  # SYMBOLSCALEDENOM 6931575 #exactly zoom level 6
 
   CLASS
     NAME 'Airports large'

--- a/mapserver/fonts/truetype.txt
+++ b/mapserver/fonts/truetype.txt
@@ -1,2 +1,2 @@
-sans /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
-serif /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans-Oblique.ttf
+sans /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+serif /usr/share/fonts/truetype/dejavu/DejaVuSans-Oblique.ttf


### PR DESCRIPTION
Apparently this broke a while ago but due to our use of `mapproxy` we did not notice this before. This PR adjusts the MapServer configuration files to be compatible with MapServer 7, which we now use on the production server.