### PR TITLE
Fix `ember-cli-uglify` configuration

### DIFF
--- a/ember/ember-cli-build.js
+++ b/ember/ember-cli-build.js
@@ -11,10 +11,8 @@ module.exports = function(defaults) {
       exclude: ['cesium'],
     },
 
-    minifyJS: {
-      options: {
-        exclude: ['cesium/Cesium.js'],
-      },
+    'ember-cli-uglify': {
+      exclude: ['cesium/**/*.js'],
     },
 
     sourcemaps: {


### PR DESCRIPTION
```
[WARN] (broccoli-uglify-sourcemap) Minifying: `cesium/Cesium.js` took: 24096ms (more than 20,000ms)
```

This PR should remove/fix the above warning message again.