### PR TITLE
Use `http` protocol for `uwsgi`

### DIFF
--- a/uwsgi/mapproxy.ini
+++ b/uwsgi/mapproxy.ini
@@ -4,6 +4,7 @@ pyargv = /home/skylines/config/mapproxy.yaml
 wsgi-file = /home/skylines/src/uwsgi/mapproxy.py
 socket = /run/skylines/mapproxy-uwsgi.socket
 stats = /run/skylines/mapproxy-uwsgi-stats.socket
+protocol = http
 processes = 1
 threads = 10
 chmod-socket = 777

--- a/uwsgi/mapserver.ini
+++ b/uwsgi/mapserver.ini
@@ -4,6 +4,7 @@ pyargv = /home/skylines/src/mapserver/skylines.map
 wsgi-file = /home/skylines/src/uwsgi/mapserver.py
 socket = /run/skylines/mapserver-uwsgi.socket
 stats = /run/skylines/mapserver-uwsgi-stats.socket
+protocol = http
 threads = 10
 chmod-socket = 777
 memory-report = True

--- a/uwsgi/skylines.ini
+++ b/uwsgi/skylines.ini
@@ -3,6 +3,7 @@ chdir = /home/skylines/src/
 wsgi-file = /home/skylines/src/uwsgi/skylines.py
 socket = /run/skylines/skylines-uwsgi.socket
 stats = /run/skylines/skylines-uwsgi-stats.socket
+protocol = http
 threads = 10
 chmod-socket = 777
 memory-report = True


### PR DESCRIPTION
This will enable us to use a different application server like gunicorn in the future without reconfiguring nginx, as well as using e.g. [Caddy](https://github.com/mholt/caddy) instead of nginx