### PR TITLE
supervisor/mapserver: Run outside of the virtualenv

### DIFF
--- a/supervisor/mapserver.conf
+++ b/supervisor/mapserver.conf
@@ -1,5 +1,5 @@
 [program:mapserver]
-command=/home/skylines/virtualenv/bin/uwsgi src/uwsgi/mapserver.ini
+command=/usr/local/bin/uwsgi src/uwsgi/mapserver.ini
 directory=/home/skylines/
 user=mapserver
 stdout_logfile=/var/log/skylines/mapserver/out.log


### PR DESCRIPTION
Unfortunately [mapscript](http://mapserver.org/de/mapscript/python.html) refuses to be installed in a normal way, and needs to be installed from the system-level package manager. This means it's not part of the usual virtualenv.

This PR changes the `supervisord` configuration to run the `mapserver` program outside of the virtualenv, so that it has access to the globally installed `mapscript` dependency.

I wish this was easier... 🤷‍♂️ 