### PR TITLE
components/comments-list: Fix table width and word wrapping

### DIFF
--- a/ember/app/templates/components/comments-list.hbs
+++ b/ember/app/templates/components/comments-list.hbs
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table" style="table-layout:fixed; word-wrap:break-word;">
   <tbody>
     {{#each comments as |comment|}}
       <tr>


### PR DESCRIPTION
Use CSS3 property `word-wrap` to wrap long strings (e.g. long URLs),
use `table-layout` property to properly set the table width according
to the parent element.

Tested in Firefox 60.0.1 and Chromium 66.0.3359.181.

Fixes #257.

I'm not sure where to set these style properties (thus resorted to inline CSS).

Previous:
![image](https://user-images.githubusercontent.com/10089607/40306767-36cee9a6-5d00-11e8-9589-de413245778a.png)

Fixed:
![image](https://user-images.githubusercontent.com/10089607/40306707-fd7f15f4-5cff-11e8-8d6a-fa79d7a20320.png)
