### PR TITLE
privacy policy: fix information regarding email address when creating an account

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -61,7 +61,7 @@ information about users.
 
 > You do not need to create an account to use SkyLines.
 >
-> If you do create an account, you do not need to give us your email address.
+> If you do create an account, you need to give us your email address.
 >
 > If you do not create an account, you are limited to viewing the flights of
 > others.


### PR DESCRIPTION
The line
`If you do create an account, you do not need to give us your email address.`
is wrong and contradictory to 
`If you want to create a standard account, we require only your name, an email
address and a password.`
So i ~~removed~~ changed it.
