### PR TITLE
Pipfile: Add `manage` script

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,9 @@ name = "pypi"
 [requires]
 python_version = "2.7"
 
+[scripts]
+manage = "./manage.py"
+
 [packages]
 flask = "==1.0.*"
 werkzeug = "*"


### PR DESCRIPTION
This allows us to use `pipenv run manage` instead of `pipenv run ./manage.py`