### PR TITLE
CI: Prevent `dependabot` branches from building twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 sudo: false
 
+branches:
+  except:
+  - /^dependabot\/.*$/
+
 language: python
 
 python:


### PR DESCRIPTION
Previously the CI jobs would be run once for the branch, and another time for the PR, which is wasting resources.

/cc @dependabot