### PR TITLE
tracking/crc: Explicitly pass bytestring to `crc16xmodem` function

### DIFF
--- a/skylines/tracking/crc.py
+++ b/skylines/tracking/crc.py
@@ -6,7 +6,7 @@ def calc_crc(data):
     assert len(data) >= 16
 
     crc = crc16xmodem(data[:4])
-    crc = crc16xmodem('\0\0', crc)
+    crc = crc16xmodem(b'\0\0', crc)
     crc = crc16xmodem(data[6:], crc)
     return crc
 


### PR DESCRIPTION
for Python 3 compatibility