### PR TITLE
tests/api/views: Set `autouse` for `db_session` fixture

### DIFF
--- a/tests/api/views/conftest.py
+++ b/tests/api/views/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def autouse_db_session(db_session):
+    pass


### PR DESCRIPTION
so that e.g. the `test_read_missing_user` test can run in isolation