### PR TITLE
api/i18n: Use list comprehension instead of `map/filter()`

### DIFF
--- a/skylines/api/views/i18n.py
+++ b/skylines/api/views/i18n.py
@@ -9,12 +9,12 @@ i18n_blueprint = Blueprint('i18n', 'skylines')
 @i18n_blueprint.route('/locale')
 def negotiate_locale():
     available = request.args.get('available', '').split(',')
-    available = filter(lambda it: it != '', available)
+    available = [locale for locale in available if locale != '']
 
     if len(available) == 0:
         return jsonify(error='invalid-request'), 400
 
-    preferred = map(lambda it: it[0], request.accept_languages)
+    preferred = [headers[0] for headers in request.accept_languages]
 
     locale = _negotiate_locale(preferred, available, sep='-')
 


### PR DESCRIPTION
for Python 3 support