### PR TITLE
model/geo: Use list comprehension instead of `map()`

### DIFF
--- a/skylines/model/geo.py
+++ b/skylines/model/geo.py
@@ -111,7 +111,7 @@ class Bounds(object):
             raise ValueError(
                 'BBox string needs to have exactly four components')
 
-        bbox = map(float, bbox)
+        bbox = [float(angle) for angle in bbox]
 
         sw = Location(latitude=bbox[1], longitude=bbox[0])
         ne = Location(latitude=bbox[3], longitude=bbox[2])


### PR DESCRIPTION
This should make the corresponding geo tests pass on Python 3