### PR TITLE
CI: Pin pipenv version to fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - redis
 
       before_install:
-        - pip install pipenv
+        - pip install pipenv==2018.7.1
 
       install:
         - pipenv install --dev


### PR DESCRIPTION
Hopefully that helps...

related to https://github.com/pypa/pipenv/pull/2968