### PR TITLE
Make `__repr__` implementations compatible with Python 3 

### DIFF
--- a/skylines/lib/string.py
+++ b/skylines/lib/string.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 from skylines.lib.types import is_bytes
 
@@ -44,3 +45,10 @@ def isnumeric(s):
         return False
 
     return True
+
+
+def unicode_to_str(value):
+    if sys.version_info[0] == 2:
+        return value.encode('utf-8')
+    else:
+        return value

--- a/skylines/model/aircraft_model.py
+++ b/skylines/model/aircraft_model.py
@@ -1,6 +1,7 @@
 from sqlalchemy.types import Integer, Unicode
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class AircraftModel(db.Model):
@@ -22,7 +23,7 @@ class AircraftModel(db.Model):
         return self.name
 
     def __repr__(self):
-        return ('<AircraftModel: id=%d name=\'%s\' kind=\'%s\'>' % (self.id, self.name, self.kind)).encode('unicode_escape')
+        return unicode_to_str('<AircraftModel: id=%d name=\'%s\' kind=\'%s\'>' % (self.id, self.name, self.kind))
 
     def is_writable(self, user):
         return user and user.is_manager()

--- a/skylines/model/airport.py
+++ b/skylines/model/airport.py
@@ -10,6 +10,7 @@ from geoalchemy2.shape import to_shape
 
 from .geo import Location
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class Airport(db.Model):
@@ -40,7 +41,7 @@ class Airport(db.Model):
         return self.name
 
     def __repr__(self):
-        return ('<Airport: id=%s name=\'%s\'>' % (self.id, self.name)).encode('unicode_escape')
+        return unicode_to_str('<Airport: id=%s name=\'%s\'>' % (self.id, self.name))
 
     @property
     def location(self):

--- a/skylines/model/airspace.py
+++ b/skylines/model/airspace.py
@@ -12,6 +12,7 @@ from flask import current_app
 
 from skylines.database import db
 from skylines.lib.geo import FEET_PER_METER
+from skylines.lib.string import unicode_to_str
 from skylines.model.geo import Location
 
 
@@ -31,7 +32,7 @@ class Airspace(db.Model):
     country_code = db.Column(String(2), nullable=False)
 
     def __repr__(self):
-        return ('<Airspace: id=%d name=\'%s\'>' % (self.id, self.name)).encode('unicode_escape')
+        return unicode_to_str('<Airspace: id=%d name=\'%s\'>' % (self.id, self.name))
 
     @classmethod
     def by_location(cls, location):

--- a/skylines/model/club.py
+++ b/skylines/model/club.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from sqlalchemy.types import Integer, Unicode, DateTime
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class Club(db.Model):
@@ -27,7 +28,7 @@ class Club(db.Model):
         return self.name
 
     def __repr__(self):
-        return ('<Club: id=%d name=\'%s\'>' % (self.id, self.name)).encode('unicode_escape')
+        return unicode_to_str('<Club: id=%d name=\'%s\'>' % (self.id, self.name))
 
     def is_writable(self, user):
         return user and (self.id == user.club_id or user.is_manager())

--- a/skylines/model/event.py
+++ b/skylines/model/event.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy.types import Integer, DateTime
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class Event(db.Model):
@@ -58,8 +59,7 @@ class Event(db.Model):
     ##############################
 
     def __repr__(self):
-        return '<Event: id={} type={}>' \
-            .format(self.id, self.type).encode('unicode_escape')
+        return unicode_to_str('<Event: id={} type={}>'.format(self.id, self.type))
 
     ##############################
 

--- a/skylines/model/flight.py
+++ b/skylines/model/flight.py
@@ -16,6 +16,7 @@ from shapely.geometry import LineString
 
 from skylines.database import db
 from skylines.lib.sql import _ST_Intersects, _ST_Contains
+from skylines.lib.string import unicode_to_str
 
 from .geo import Location
 from .igcfile import IGCFile
@@ -105,8 +106,7 @@ class Flight(db.Model):
     ##############################
 
     def __repr__(self):
-        return ('<Flight: id=%s, modified=%s>'
-                % (self.id, self.time_modified)).encode('unicode_escape')
+        return unicode_to_str('<Flight: id=%s, modified=%s>' % (self.id, self.time_modified))
 
     ##############################
 

--- a/skylines/model/flight_comment.py
+++ b/skylines/model/flight_comment.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy.types import Unicode, Integer, DateTime
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class FlightComment(db.Model):
@@ -25,4 +26,4 @@ class FlightComment(db.Model):
     text = db.Column(Unicode, nullable=False)
 
     def __repr__(self):
-        return ('<FlightComment: id=%d user_id=%d flight_id=%d>' % (self.id, self.user_id, self.flight_id)).encode('unicode_escape')
+        return unicode_to_str('<FlightComment: id=%d user_id=%d flight_id=%d>' % (self.id, self.user_id, self.flight_id))

--- a/skylines/model/igcfile.py
+++ b/skylines/model/igcfile.py
@@ -9,6 +9,7 @@ from sqlalchemy.types import Integer, DateTime, String, Unicode, Date
 from skylines.database import db
 from skylines.lib import files
 from skylines.lib.igc import read_igc_headers
+from skylines.lib.string import unicode_to_str
 
 
 class IGCFile(db.Model):
@@ -33,7 +34,7 @@ class IGCFile(db.Model):
     date_utc = db.Column(Date, nullable=False)
 
     def __repr__(self):
-        return ('<IGCFile: id=%d filename=\'%s\'>' % (self.id, self.filename)).encode('unicode_escape')
+        return unicode_to_str('<IGCFile: id=%d filename=\'%s\'>' % (self.id, self.filename))
 
     @classmethod
     def by_md5(cls, _md5):

--- a/skylines/model/mountain_wave_project.py
+++ b/skylines/model/mountain_wave_project.py
@@ -8,6 +8,7 @@ from geoalchemy2.types import Geography, Geometry
 
 from skylines.database import db
 from skylines.model.geo import Location
+from skylines.lib.string import unicode_to_str
 
 
 class MountainWaveProject(db.Model):
@@ -36,7 +37,7 @@ class MountainWaveProject(db.Model):
     axis_length = db.Column(Float)
 
     def __repr__(self):
-        return ('<MountainWaveProject: id=%d name=\'%s\'>' % (self.id, self.name)).encode('unicode_escape')
+        return unicode_to_str('<MountainWaveProject: id=%d name=\'%s\'>' % (self.id, self.name))
 
     @classmethod
     def by_location(cls, location):

--- a/skylines/model/notification.py
+++ b/skylines/model/notification.py
@@ -4,6 +4,7 @@ from itertools import chain
 from sqlalchemy.types import Integer, DateTime
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 from .event import Event
 from .user import User
 from .club import Club
@@ -35,8 +36,7 @@ class Notification(db.Model):
     ##############################
 
     def __repr__(self):
-        return '<Notification: id={}>' \
-            .format(self.id).encode('unicode_escape')
+        return unicode_to_str('<Notification: id={}>'.format(self.id))
 
     ##############################
 

--- a/skylines/model/timezone.py
+++ b/skylines/model/timezone.py
@@ -3,6 +3,7 @@ from sqlalchemy.types import Integer, String
 from geoalchemy2.types import Geometry
 
 from skylines.database import db
+from skylines.lib.string import unicode_to_str
 
 
 class TimeZone(db.Model):
@@ -16,7 +17,7 @@ class TimeZone(db.Model):
         return self.tzid
 
     def __repr__(self):
-        return ('<TimeZone: id=%d tzid=\'%s\'>' % (self.id, self.tzid)).encode('unicode_escape')
+        return unicode_to_str('<TimeZone: id=%d tzid=\'%s\'>' % (self.id, self.tzid))
 
     @classmethod
     def by_location(cls, location):

--- a/skylines/model/tracking.py
+++ b/skylines/model/tracking.py
@@ -11,6 +11,7 @@ from shapely.geometry import Point
 
 from skylines.database import db
 from skylines.lib.types import is_int
+from skylines.lib.string import unicode_to_str
 from .geo import Location
 
 
@@ -40,8 +41,7 @@ class TrackingFix(db.Model):
     ip = db.Column(INET)
 
     def __repr__(self):
-        return '<TrackingFix: id={} time=\'{}\'>' \
-               .format(self.id, self.time).encode('unicode_escape')
+        return unicode_to_str('<TrackingFix: id={} time=\'{}\'>'.format(self.id, self.time))
 
     @property
     def location(self):
@@ -146,7 +146,7 @@ class TrackingSession(db.Model):
     finish_status = db.Column(SmallInteger)
 
     def __repr__(self):
-        return '<TrackingSession: id={}>'.format(self.id).encode('unicode_escape')
+        return unicode_to_str('<TrackingSession: id={}>'.format(self.id))
 
     @classmethod
     def by_lt24_id(cls, lt24_id, filter_finished=True):

--- a/skylines/model/user.py
+++ b/skylines/model/user.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
 from skylines.database import db
 from skylines.lib import files
 from skylines.lib.sql import LowerCaseComparator
+from skylines.lib.string import unicode_to_str
 from skylines.lib.types import is_unicode
 
 __all__ = ['User']
@@ -89,8 +90,9 @@ class User(db.Model):
     ##############################
 
     def __repr__(self):
-        return ('<User: email=%s, display=%s>' % (
-                self.email_address, self.name)).encode('unicode_escape')
+        return unicode_to_str(
+            '<User: email=%s, display=%s>' % (self.email_address, self.name)
+        )
 
     def __unicode__(self):
         return self.name

--- a/tests/model/test_user.py
+++ b/tests/model/test_user.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import pytest
 
@@ -43,3 +45,12 @@ def test_user_delete_deletes_owned_igc_files(db_session):
 
     assert db_session.query(IGCFile).count() == 0
     assert not os.path.isfile(files.filename_to_path(filename))
+
+
+def test_repr_is_str(db_session):
+    john = users.john(last_name=u'Müller')
+    db_session.add(john)
+    db_session.commit()
+
+    assert isinstance(repr(john), str)
+    assert repr(john) == '<User: email=johnny@doe.com, display=John Müller>'


### PR DESCRIPTION
`__repr__` is always supposed to return `str` ("bytes" in Python 2, "unicode" in Python 3)