### PR TITLE
lib/types: Ignore "undefined name" warnings

### DIFF
--- a/skylines/lib/types.py
+++ b/skylines/lib/types.py
@@ -1,3 +1,5 @@
+# flake8: noqa F821
+
 import sys
 
 


### PR DESCRIPTION
This file handles Python 2/3 compat and is expected to have undefined names in the branches that don't run for the corresponding versions