### PR TITLE
api/views: Use `.name` instead of `unicode()` conversion

### DIFF
--- a/skylines/api/views/notifications.py
+++ b/skylines/api/views/notifications.py
@@ -81,17 +81,17 @@ def convert_event(e):
         "id": e.id,
         "type": TYPES.get(e.type, "unknown"),
         "time": e.time.isoformat(),
-        "actor": {"id": e.actor_id, "name": unicode(e.actor)},
+        "actor": {"id": e.actor_id, "name": e.actor.name},
     }
 
     if hasattr(e, "unread"):
         event["unread"] = e.unread
 
     if e.user_id:
-        event["user"] = {"id": e.user_id, "name": unicode(e.user)}
+        event["user"] = {"id": e.user_id, "name": e.user.name}
 
     if e.club_id:
-        event["club"] = {"id": e.club_id, "name": unicode(e.club)}
+        event["club"] = {"id": e.club_id, "name": e.club.name}
 
     if e.flight_id:
         event["flight"] = {

--- a/skylines/api/views/statistics.py
+++ b/skylines/api/views/statistics.py
@@ -26,18 +26,18 @@ def index(page=None, id=None):
 
     if page == "pilot":
         pilot = get_requested_record(User, id)
-        name = unicode(pilot)
+        name = pilot.name
         query = query.filter(Flight.pilot_id == pilot.id)
 
     elif page == "club":
         club = get_requested_record(Club, id)
-        name = unicode(club)
+        name = club.name
         query = query.filter(Flight.club_id == club.id)
         pilots_query = pilots_query.filter(Flight.club_id == club.id)
 
     elif page == "airport":
         airport = get_requested_record(Airport, id)
-        name = unicode(airport)
+        name = airport.name
         query = query.filter(Flight.takeoff_airport_id == airport.id)
         pilots_query = pilots_query.filter(Flight.takeoff_airport_id == airport.id)
 

--- a/skylines/api/views/tracking.py
+++ b/skylines/api/views/tracking.py
@@ -71,7 +71,7 @@ def latest():
         json = dict(
             time=fix.time.isoformat() + "Z",
             location=fix.location.to_wkt(),
-            pilot=dict(id=fix.pilot_id, name=unicode(fix.pilot)),
+            pilot=dict(id=fix.pilot_id, name=fix.pilot.name),
         )
 
         optional_attributes = [

--- a/skylines/api/views/users.py
+++ b/skylines/api/views/users.py
@@ -114,7 +114,7 @@ password, click on the following link:
 
 The SkyLines Team
 """ % (
-        unicode(user),
+        user.name,
         request.remote_addr,
         user.recover_key,
     )


### PR DESCRIPTION
for Python 3 compat