### PR TITLE
pipenv: Remove broken extra markers

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -68,7 +68,6 @@
             "hashes": [
                 "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
             ],
-            "markers": "extra == 'flask'",
             "version": "==1.4"
         },
         "celery": {
@@ -433,7 +432,6 @@
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
                 "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
-            "markers": "extra == 'redis'",
             "version": "==2.10.6"
         },
         "requests": {


### PR DESCRIPTION
see https://github.com/pypa/pipenv/issues/3026