### PR TITLE
mapproxy: Remove explicit cache folder settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Generated Ember.js files
 skylines/frontend/static
 
+# MapProxy Cache
+/mapproxy/cache_data/
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/INSTALL.mapserver.md
+++ b/INSTALL.mapserver.md
@@ -6,7 +6,7 @@ package (on Debian):
     $ apt-get install python-mapscript
 
 To run it locally as subprocess of mapproxy, change
-`mapserver/mapproxy/mapproxy.yaml` to fit it to your needs. You'll need to
+`mapproxy/mapproxy.yaml` to fit it to your needs. You'll need to
 install the `cgi-mapserver` package for this.
 
 To import airspaces into the database, install the `python-gdal` package (using

--- a/fabfile.py
+++ b/fabfile.py
@@ -61,11 +61,6 @@ def manage(cmd, user=None):
 
 
 @task
-def update_mapproxy():
-    put("mapproxy/mapproxy.yaml", "%s/config/mapproxy.yaml" % APP_DIR)
-
-
-@task
 def pip_install():
     with cd(SRC_DIR):
         run("git reset --hard")

--- a/fabfile.py
+++ b/fabfile.py
@@ -62,22 +62,7 @@ def manage(cmd, user=None):
 
 @task
 def update_mapproxy():
-    with NamedTemporaryFile() as f:
-        content = open("mapproxy/mapproxy.yaml").read()
-
-        content = content.replace(
-            "base_dir: '/tmp/cache_data'", "base_dir: '%s/cache/mapproxy'" % APP_DIR
-        )
-
-        content = content.replace(
-            "lock_dir: '/tmp/cache_data/tile_locks'",
-            "lock_dir: '%s/cache/mapproxy/tile_locks'" % APP_DIR,
-        )
-
-        f.write(content)
-        f.flush()
-
-        put(f.name, "%s/config/mapproxy.yaml" % APP_DIR)
+    put("mapproxy/mapproxy.yaml", "%s/config/mapproxy.yaml" % APP_DIR)
 
 
 @task
@@ -89,5 +74,5 @@ def pip_install():
 
 @task
 def clean_mapproxy_cache():
-    with cd("/home/skylines/cache/mapproxy"):
-        run("rm -rv *")
+    with cd(SRC_DIR):
+        run("rm -rv mapproxy/cache_data/")

--- a/fabfile.py
+++ b/fabfile.py
@@ -63,7 +63,7 @@ def manage(cmd, user=None):
 @task
 def update_mapproxy():
     with NamedTemporaryFile() as f:
-        content = open("mapserver/mapproxy/mapproxy.yaml").read()
+        content = open("mapproxy/mapproxy.yaml").read()
 
         content = content.replace(
             "base_dir: '/tmp/cache_data'", "base_dir: '%s/cache/mapproxy'" % APP_DIR

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -188,10 +188,6 @@ globals:
 
   # # cache options
   cache:
-    # where to store the cached images
-    base_dir: '/tmp/cache_data'
-    # where to store lockfiles
-    lock_dir: '/tmp/cache_data/locks'
     # request x*y tiles in one step
     meta_size: [6, 6]
     # add a buffer on all sides (in pixel) when requesting

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -97,39 +97,39 @@ sources:
     supported_srs: ['EPSG:3857']
     req:
       layers: MWP
-      map: ../skylines.map
+      map: ../mapserver/skylines.map
       transparent: true
     image:
       format: image/png
     mapserver:
       binary: /usr/lib/cgi-bin/mapserv
-      working_dir: ../
+      working_dir: ../mapserver
 
   airports_mapserver_bin:
     type: mapserver
     supported_srs: ['EPSG:3857']
     req:
       layers: Airports
-      map: ../skylines.map
+      map: ../mapserver/skylines.map
       transparent: true
     image:
       format: image/png
     mapserver:
       binary: /usr/lib/cgi-bin/mapserv
-      working_dir: ../
+      working_dir: ../mapserver
 
   airspace_mapserver_bin:
     type: mapserver
     supported_srs: ['EPSG:3857']
     req:
       layers: Airspace
-      map: ../skylines.map
+      map: ../mapserver/skylines.map
       transparent: true
     image:
       format: image/png
     mapserver:
       binary: /usr/lib/cgi-bin/mapserv
-      working_dir: ../
+      working_dir: ../mapserver
 
   mwp_mapserver_wms:
     type: wms

--- a/uwsgi/mapproxy.ini
+++ b/uwsgi/mapproxy.ini
@@ -1,6 +1,6 @@
 [uwsgi]
 chdir = /home/skylines/src/
-pyargv = /home/skylines/config/mapproxy.yaml
+pyargv = /home/skylines/src/mapproxy/mapproxy.yaml
 wsgi-file = /home/skylines/src/uwsgi/mapproxy.py
 socket = /run/skylines/mapproxy-uwsgi.socket
 stats = /run/skylines/mapproxy-uwsgi-stats.socket


### PR DESCRIPTION
This will keep the cache in the `cache_data` folder right next to the config file in the top-level `mapproxy` folder. That means we no longer need to use a different file on the production server, which then means that relative paths in the `mapproxy.yaml` file will work properly again.