### PR TITLE
Caddy: Simplify `expires` configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -22,11 +22,8 @@ skylines.aero {
         match ^/assets/.*\.css$ 1y
         match ^/assets/.*\.js$ 1y
         match ^/fonts 1y
-        match ^/api 0s
-        match ^/client.php 0s
-        match ^/track.php 0s
-        match ^/widgets 0s
         match ^/mapproxy 7d
+        match .* 0s
     }
 
     proxy /api unix:/run/skylines/skylines-uwsgi.socket {


### PR DESCRIPTION
Previously the `index.html` file did not have an `Expires` header, which meant that it was cached locally in the browser for a while, which is certainly not what we want. This PR sets `expires: 0s` for all responses that don't have any other configuration set.