### PR TITLE
uwsgi: Serve on TCP sockets

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -26,27 +26,27 @@ skylines.aero {
         match .* 0s
     }
 
-    proxy /api unix:/run/skylines/skylines-uwsgi.socket {
+    proxy /api http://localhost:9115 {
         transparent
     }
 
-    proxy /files unix:/run/skylines/skylines-uwsgi.socket {
+    proxy /files http://localhost:9115 {
         transparent
     }
 
-    proxy /client.php unix:/run/skylines/skylines-uwsgi.socket {
+    proxy /client.php http://localhost:9115 {
         transparent
     }
 
-    proxy /track.php unix:/run/skylines/skylines-uwsgi.socket {
+    proxy /track.php http://localhost:9115 {
         transparent
     }
 
-    proxy /widgets unix:/run/skylines/skylines-uwsgi.socket {
+    proxy /widgets http://localhost:9115 {
         transparent
     }
 
-    proxy /mapproxy unix:/run/skylines/mapproxy-uwsgi.socket {
+    proxy /mapproxy http://localhost:9109 {
         transparent
         without /mapproxy
     }

--- a/uwsgi/mapproxy.ini
+++ b/uwsgi/mapproxy.ini
@@ -2,8 +2,7 @@
 chdir = /home/skylines/src/
 pyargv = /home/skylines/src/mapproxy/mapproxy.yaml
 wsgi-file = /home/skylines/src/uwsgi/mapproxy.py
-socket = /run/skylines/mapproxy-uwsgi.socket
-stats = /run/skylines/mapproxy-uwsgi-stats.socket
+http-socket = 127.0.0.1:9109
 protocol = http
 processes = 1
 threads = 10

--- a/uwsgi/skylines.ini
+++ b/uwsgi/skylines.ini
@@ -1,8 +1,7 @@
 [uwsgi]
 chdir = /home/skylines/src/
 wsgi-file = /home/skylines/src/uwsgi/skylines.py
-socket = /run/skylines/skylines-uwsgi.socket
-stats = /run/skylines/skylines-uwsgi-stats.socket
+http-socket = 127.0.0.1:9115
 protocol = http
 threads = 10
 chmod-socket = 777


### PR DESCRIPTION
While supposedly not as efficient as UNIX sockets, TCP sockets make things a little easier to handle with regard to filesystem permissions