### PR TITLE
Revert `redis` back to v2.10.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ shapely = "==1.6.4.post2"
 "crc16" = "==0.1.1"
 pytz = "*"
 celery = {extras = ["redis"], version = "<3.2,>=3.1"}
+redis = "<3.0"
 xcsoar = "==0.6.4"
 aerofiles = "==1.0.0"
 "enum34" = "==1.1.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6d5c93fdbb5878be22ca3e8fab0269d47aab44c0a4dac8e7ebe0bb6d5a97783e"
+            "sha256": "0fd3602190a40b25c9975c1204c850bcc462de9a1e4f181a9ef335313d4892ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -456,10 +456,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:2100750629beff143b6a200a2ea8e719fcf26420adabb81402895e144c5083cf",
-                "sha256:8e0bdd2de02e829b6225b25646f9fb9daffea99a252610d040409a6738541f0a"
+                "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
+                "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
-            "version": "==3.0.1"
+            "index": "pypi",
+            "version": "==2.10.6"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
`redis@3` is apparently not compatible with our current Celery version 😢 