### PR TITLE
Caddy: Add `www02` and `tracking` redirections

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -59,6 +59,14 @@ www.skylines.aero {
     redir https://skylines.aero{uri}
 }
 
+www02.skylines.aero {
+    redir https://skylines.aero{uri}
+}
+
+tracking.skylines.aero {
+    redir https://skylines.aero/tracking/
+}
+
 maps.skylines.aero {
     redir https://skylines.aero{uri}
 }


### PR DESCRIPTION
`www02.skylines.aero` is the domain of the new server and will redirect to `skylines.aero` as the main domain now.

`tracking.skylines.aero` is used by XCSoar v7 as the live tracking endpoint. just in case someone tries to access it via HTTP we will redirect them to the right browser URL.