### PR TITLE
Remove `journald` logging

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
 # https://caddyserver.com configuration for the production server
 
 skylines.aero {
-    log stdout
+    log /home/skylines/log/caddy
 
     root /home/skylines/src/skylines/frontend/static
     gzip

--- a/systemd/mapproxy.service
+++ b/systemd/mapproxy.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 SyslogIdentifier=mapproxy
 WorkingDirectory=/home/skylines/src
-ExecStart=/usr/local/bin/pipenv run gunicorn -b 127.0.0.1:9109 -w 10 --no-sendfile --access-logfile="-" wsgi_mapproxy
+ExecStart=/usr/local/bin/pipenv run gunicorn -b 127.0.0.1:9109 -w 10 --no-sendfile wsgi_mapproxy
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/systemd/skylines.service
+++ b/systemd/skylines.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 SyslogIdentifier=skylines
 WorkingDirectory=/home/skylines/src
-ExecStart=/usr/local/bin/pipenv run gunicorn -b 127.0.0.1:9115 -w 10 --no-sendfile --access-logfile="-" wsgi_skylines
+ExecStart=/usr/local/bin/pipenv run gunicorn -b 127.0.0.1:9115 -w 10 --no-sendfile wsgi_skylines
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true


### PR DESCRIPTION
Apparently `journald` is not meant for "high-frequency logging" like webserver access logs. This PR changes the logging strategy back to files or not logging access logs at all.

/cc @lordfolken 