### PR TITLE
routes/search: Use params.text as searchText

### DIFF
--- a/ember/app/routes/search.js
+++ b/ember/app/routes/search.js
@@ -11,8 +11,8 @@ export default Route.extend({
     },
   },
 
-  model(params, transition) {
-    let searchText = transition.queryParams && transition.queryParams.text;
+  model(params) {
+    let searchText = params.text;
     this.set('searchTextService.text', searchText);
 
     if (searchText) {


### PR DESCRIPTION
This fixes a regression introduced by dbf6802 since accessing
`queryParams` on the `Transition` have been deprecated in
Ember v3.x and removed in v3.10.

Fixes #1641.