### PR TITLE
systemd/celery: Always restart `celery` service

### DIFF
--- a/systemd/celery.service
+++ b/systemd/celery.service
@@ -6,7 +6,7 @@ After=network.target
 SyslogIdentifier=celery
 WorkingDirectory=/home/skylines/src
 ExecStart=/usr/local/bin/pipenv run python manage.py celery runworker
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Our celery service currently does not seem to restart itself when it quits for unknown reasons. This change does not fix the unknown issue that causes celery to crash, but should hopefully at least cause it to restart itself whenever it quits on its own.

This should avoid issues like https://github.com/skylines-project/skylines/issues/1529 in the future.