### PR TITLE
Replace `this.$()` calls

### DIFF
--- a/ember/app/components/base-barogram.js
+++ b/ember/app/components/base-barogram.js
@@ -69,7 +69,7 @@ export default Component.extend({
       };
     }
 
-    let placeholder = this.$('div');
+    let placeholder = $(this.element.querySelector('div'));
 
     this.set('placeholder', placeholder);
     this.set('flot', $.plot(placeholder, [], opts));

--- a/ember/app/components/date-picker.js
+++ b/ember/app/components/date-picker.js
@@ -1,5 +1,7 @@
 import Component from '@ember/component';
 
+import $ from 'jquery';
+
 import isoDate from '../utils/iso-date';
 
 export default Component.extend({
@@ -10,7 +12,7 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    let picker = this.$('span').datepicker({
+    let picker = $(this.element.querySelector('span')).datepicker({
       weekStart: 1,
     });
 

--- a/ember/app/components/datetime-picker.js
+++ b/ember/app/components/datetime-picker.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
 import { once } from '@ember/runloop';
 
+import $ from 'jquery';
+
 export default Component.extend({
   classNames: ['input-group', 'input-group-sm', 'date'],
 
@@ -11,7 +13,10 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    this.$().datetimepicker({
+
+    let $element = $(this.element);
+
+    $element.datetimepicker({
       pickDate: false,
       useSeconds: true,
       format: 'HH:mm:ss',
@@ -25,11 +30,11 @@ export default Component.extend({
       maxDate: this.maxDate,
     });
 
-    this.$().on('dp.change', ({ date }) => {
+    $element.on('dp.change', ({ date }) => {
       this.onChange(date.toDate());
     });
 
-    this.set('picker', this.$().data('DateTimePicker'));
+    this.set('picker', $element.data('DateTimePicker'));
 
     once(this, 'updateDate');
   },
@@ -41,7 +46,7 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    this.$().off('dp.change');
+    $(this.element).off('dp.change');
     this.set('picker', null);
   },
 

--- a/ember/app/components/flight-page.js
+++ b/ember/app/components/flight-page.js
@@ -2,6 +2,8 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
+import $ from 'jquery';
+
 import FixCalc from '../utils/fix-calc';
 import FlighPhase from '../utils/flight-phase';
 
@@ -48,24 +50,31 @@ export default Component.extend({
     this._super(...arguments);
     let fixCalc = this.fixCalc;
 
-    let sidebar = this.$('#sidebar').sidebar();
+    let sidebar = this.element.querySelector('#sidebar');
+    let $sidebar = $(sidebar).sidebar();
+
+    let barogramPanel = this.element.querySelector('#barogram_panel');
+    let $barogramPanel = $(barogramPanel);
+
+    let olScaleLine = this.element.querySelector('.ol-scale-line');
+    let olAttribution = this.element.querySelector('.ol-attribution');
 
     let resize = () => {
-      let $barogramPanel = this.$('#barogram_panel');
-      let bottom = Number($barogramPanel.css('bottom').replace('px', ''));
-      let height = $barogramPanel.height() + bottom;
-      sidebar.css('bottom', height);
-      this.$('.ol-scale-line').css('bottom', height);
-      this.$('.ol-attribution').css('bottom', height);
+      let bottom = Number(getComputedStyle(barogramPanel).bottom.replace('px', ''));
+      let height = barogramPanel.offsetHeight + bottom;
+
+      sidebar.style.bottom = `${height}px`;
+      olScaleLine.style.bottom = `${height}px`;
+      olAttribution.style.bottom = `${height}px`;
     };
 
     resize();
-    this.$('#barogram_panel').resize(resize);
+    $barogramPanel.resize(resize);
 
-    if (window.location.hash && sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {
-      sidebar.open(window.location.hash.substring(1));
+    if (window.location.hash && sidebar.querySelector(`li > a[href="#${window.location.hash.substring(1)}"]`)) {
+      $sidebar.open(window.location.hash.substring(1));
     } else if (window.innerWidth >= 768) {
-      sidebar.open('tab-overview');
+      $sidebar.open('tab-overview');
     }
 
     let [primaryId, ...otherIds] = this.ids;
@@ -118,6 +127,8 @@ export default Component.extend({
   },
 
   _calculatePadding() {
-    return [20, 20, this.$('#barogram_panel').height() + 20, this.$('#sidebar').width() + 20];
+    let sidebar = this.element.querySelector('#sidebar');
+    let barogramPanel = this.element.querySelector('#barogram_panel');
+    return [20, 20, barogramPanel.offsetHeight + 20, sidebar.offsetWidth + 20];
   },
 });

--- a/ember/app/components/tracking-page.js
+++ b/ember/app/components/tracking-page.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import { cancel, later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
+import $ from 'jquery';
 import ol from 'openlayers';
 
 import FixCalc from '../utils/fix-calc';
@@ -49,24 +50,31 @@ export default Component.extend({
 
     let fixCalc = this.fixCalc;
 
-    let sidebar = this.$('#sidebar').sidebar();
+    let sidebar = this.element.querySelector('#sidebar');
+    let $sidebar = $(sidebar).sidebar();
+
+    let barogramPanel = this.element.querySelector('#barogram_panel');
+    let $barogramPanel = $(barogramPanel);
+
+    let olScaleLine = this.element.querySelector('.ol-scale-line');
+    let olAttribution = this.element.querySelector('.ol-attribution');
 
     let resize = () => {
-      let $barogramPanel = this.$('#barogram_panel');
-      let bottom = Number($barogramPanel.css('bottom').replace('px', ''));
-      let height = $barogramPanel.height() + bottom;
-      sidebar.css('bottom', height);
-      this.$('.ol-scale-line').css('bottom', height);
-      this.$('.ol-attribution').css('bottom', height);
+      let bottom = Number(getComputedStyle(barogramPanel).bottom.replace('px', ''));
+      let height = barogramPanel.offsetHeight + bottom;
+
+      sidebar.style.bottom = `${height}px`;
+      olScaleLine.style.bottom = `${height}px`;
+      olAttribution.style.bottom = `${height}px`;
     };
 
     resize();
-    this.$('#barogram_panel').resize(resize);
+    $barogramPanel.resize(resize);
 
-    if (window.location.hash && sidebar.find(`li > a[href="#${window.location.hash.substring(1)}"]`).length !== 0) {
-      sidebar.open(window.location.hash.substring(1));
+    if (window.location.hash && sidebar.querySelector(`li > a[href="#${window.location.hash.substring(1)}"]`)) {
+      $sidebar.open(window.location.hash.substring(1));
     } else if (window.innerWidth >= 768 && flights.length > 1) {
-      sidebar.open('tab-overview');
+      $sidebar.open('tab-overview');
     }
 
     let map = window.flightMap.get('map');
@@ -131,7 +139,9 @@ export default Component.extend({
   },
 
   _calculatePadding() {
-    return [20, 20, this.$('#barogram_panel').height() + 20, this.$('#sidebar').width() + 20];
+    let sidebar = this.element.querySelector('#sidebar');
+    let barogramPanel = this.element.querySelector('#barogram_panel');
+    return [20, 20, barogramPanel.offsetHeight + 20, sidebar.offsetWidth + 20];
   },
 });
 

--- a/ember/app/components/upload-flight-form.js
+++ b/ember/app/components/upload-flight-form.js
@@ -52,7 +52,7 @@ export default Component.extend(Validations, {
   },
 
   uploadTask: task(function*() {
-    let form = this.$('form').get(0);
+    let form = this.element.querySelector('form');
     let data = new FormData(form);
 
     try {


### PR DESCRIPTION
This is getting rid of all `this.$()` calls in the app to fix the corresponding deprecation warnings.