### PR TITLE
Disable jQuery integration

### DIFF
--- a/ember/config/optional-features.json
+++ b/ember/config/optional-features.json
@@ -1,4 +1,5 @@
 {
   "application-template-wrapper": false,
+  "jquery-integration": false,
   "template-only-glimmer-components": true
 }

--- a/ember/package.json
+++ b/ember/package.json
@@ -20,6 +20,7 @@
     "remarkable": "^1.7.2"
   },
   "devDependencies": {
+    "@ember/jquery": "^1.0.0",
     "@ember/optional-features": "^1.0.0",
     "@pollyjs/ember": "^2.6.3",
     "bigscreen": "^2.0.5",

--- a/ember/yarn.lock
+++ b/ember/yarn.lock
@@ -954,6 +954,18 @@
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.1.1.tgz#d5732c3da593f202e6e1ac6dbee56a758242403f"
   integrity sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==
 
+"@ember/jquery@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-1.0.0.tgz#f49cb5aa500be709f161b668536e38dbccbb789f"
+  integrity sha512-PFXjkCY3uOqliEI2vU8Dl+x/vJ5qQuiZ9Zk2sgvbXAzRs7bYvQkioFB04LvUmEdMHzuVgNHniRF3RiaSbveaKw==
+  dependencies:
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    ember-cli-babel "^7.11.1"
+    ember-cli-version-checker "^3.1.3"
+    jquery "^3.4.1"
+    resolve "^1.11.1"
+
 "@ember/optional-features@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-1.0.0.tgz#8e54ff37f4d9642212b45387f182cf7322aaaab9"
@@ -5151,7 +5163,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.12.0.tgz#064997d199384be8c88d251f30ef67953d3bddc5"
   integrity sha512-+EGQsbPvh19nNXHCm6rVBx2CdlxQlzxMyhey5hsGViDPriDI4PFYXYaFWdGizDrmZoDcG/Ywpeph3hl0NxGQTg==


### PR DESCRIPTION
We no longer use `this.$()` and jQuery itself will be provided by `@ember/jquery` now.