### PR TITLE
freestyle: Add `datetime-picker` usage example

### DIFF
--- a/ember/lib/freestyle/app/components/usage/datetime-picker.js
+++ b/ember/lib/freestyle/app/components/usage/datetime-picker.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: '',
+});

--- a/ember/lib/freestyle/app/templates/components/usage/datetime-picker.hbs
+++ b/ember/lib/freestyle/app/templates/components/usage/datetime-picker.hbs
@@ -1,0 +1,6 @@
+{{#freestyle-usage "datetime-picker"}}
+  <DatetimePicker
+    @date={{this.takeoffTime}}
+    @onChange={{action (mut this.takeoffTime)}}
+  />
+{{/freestyle-usage}}


### PR DESCRIPTION
because it needs to be testable outside of the flight upload flow