### PR TITLE
igc: Allow `HFDTEDATE:` headers

### DIFF
--- a/skylines/lib/igc.py
+++ b/skylines/lib/igc.py
@@ -9,7 +9,7 @@ from . import base36
 from .string import import_ascii, import_alnum
 from skylines.lib.types import is_string, is_bytes
 
-hfdte_re = re.compile(br"HFDTE(\d{6})", re.IGNORECASE)
+hfdte_re = re.compile(br"HFDTE(?:DATE:?)?(\d{6})", re.IGNORECASE)
 hfgid_re = re.compile(br"HFGID\s*GLIDER\s*ID\s*:(.*)", re.IGNORECASE)
 hfgty_re = re.compile(br"HFGTY\s*GLIDER\s*TYPE\s*:(.*)", re.IGNORECASE)
 hfcid_re = re.compile(br"HFCID.*:(.*)", re.IGNORECASE)

--- a/tests/lib/test_igc.py
+++ b/tests/lib/test_igc.py
@@ -47,6 +47,12 @@ def test_date_only():
     )
 
 
+def test_long_date():
+    assert read_igc_headers([b"HFDTEDATE:150812,02"]) == dict(
+        date_utc=datetime.date(2012, 8, 15)
+    )
+
+
 def test_glider_information():
     headers = read_igc_headers(
         [


### PR DESCRIPTION
Looks like the Naviter Oudie is producing such headers now and according to the IGC file spec they are valid 🤷‍♂️ 