### PR TITLE
Flight|TrackingPage: Unwrap `ArrayProxy` before handing `flights` to `FlightBarogram`

### DIFF
--- a/ember/app/templates/components/flight-page.hbs
+++ b/ember/app/templates/components/flight-page.hbs
@@ -116,7 +116,7 @@
     </div>
 
     <FlightBarogram
-      @flights={{fixCalc.flights}}
+      @flights={{fixCalc.flights.content}}
       @selection={{selectedFlightId}}
       @hoverMode={{not fixCalc.isRunning}}
       @timeInterval={{timeInterval}}

--- a/ember/app/templates/components/tracking-page.hbs
+++ b/ember/app/templates/components/tracking-page.hbs
@@ -47,7 +47,7 @@
       </div>
 
       <FlightBarogram
-        @flights={{fixCalc.flights}}
+        @flights={{fixCalc.flights.content}}
         @selection={{selectedFlightId}}
         @hoverMode={{not fixCalc.isRunning}}
         @timeInterval={{timeInterval}}


### PR DESCRIPTION
This is a bad workaround, but it unblocks the update to Ember 3.16/3.19.