### PR TITLE
Fix format unit helper invalidation when locale changes

### DIFF
--- a/ember/app/helpers/format-altitude.js
+++ b/ember/app/helpers/format-altitude.js
@@ -1,13 +1,8 @@
 import Helper from '@ember/component/helper';
-import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Helper.extend({
   units: service(),
-
-  altitudeUnitObserver: observer('units.altitudeUnit', function () {
-    this.recompute();
-  }),
 
   compute([value], options) {
     return this.units.formatAltitude(value, options);

--- a/ember/app/helpers/format-altitude.js
+++ b/ember/app/helpers/format-altitude.js
@@ -2,10 +2,10 @@ import { inject as service } from '@ember/service';
 
 import BaseHelper from 'ember-intl/helpers/-format-base';
 
-export default BaseHelper.extend({
-  units: service(),
+export default class extends BaseHelper {
+  @service units;
 
   format(value, options) {
     return this.units.formatAltitude(value, options);
-  },
-});
+  }
+}

--- a/ember/app/helpers/format-altitude.js
+++ b/ember/app/helpers/format-altitude.js
@@ -1,10 +1,11 @@
-import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-export default Helper.extend({
+import BaseHelper from 'ember-intl/helpers/-format-base';
+
+export default BaseHelper.extend({
   units: service(),
 
-  compute([value], options) {
+  format(value, options) {
     return this.units.formatAltitude(value, options);
   },
 });

--- a/ember/app/helpers/format-distance.js
+++ b/ember/app/helpers/format-distance.js
@@ -1,13 +1,8 @@
 import Helper from '@ember/component/helper';
-import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Helper.extend({
   units: service(),
-
-  distanceUnitObserver: observer('units.distanceUnit', function () {
-    this.recompute();
-  }),
 
   compute([value], options) {
     return this.units.formatDistance(value, options);

--- a/ember/app/helpers/format-distance.js
+++ b/ember/app/helpers/format-distance.js
@@ -2,10 +2,10 @@ import { inject as service } from '@ember/service';
 
 import BaseHelper from 'ember-intl/helpers/-format-base';
 
-export default BaseHelper.extend({
-  units: service(),
+export default class extends BaseHelper {
+  @service units;
 
   format(value, options) {
     return this.units.formatDistance(value, options);
-  },
-});
+  }
+}

--- a/ember/app/helpers/format-distance.js
+++ b/ember/app/helpers/format-distance.js
@@ -1,10 +1,11 @@
-import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-export default Helper.extend({
+import BaseHelper from 'ember-intl/helpers/-format-base';
+
+export default BaseHelper.extend({
   units: service(),
 
-  compute([value], options) {
+  format(value, options) {
     return this.units.formatDistance(value, options);
   },
 });

--- a/ember/app/helpers/format-lift.js
+++ b/ember/app/helpers/format-lift.js
@@ -1,13 +1,8 @@
 import Helper from '@ember/component/helper';
-import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Helper.extend({
   units: service(),
-
-  liftUnitObserver: observer('units.liftUnit', function () {
-    this.recompute();
-  }),
 
   compute([value], options) {
     return this.units.formatLift(value, options);

--- a/ember/app/helpers/format-lift.js
+++ b/ember/app/helpers/format-lift.js
@@ -2,10 +2,10 @@ import { inject as service } from '@ember/service';
 
 import BaseHelper from 'ember-intl/helpers/-format-base';
 
-export default BaseHelper.extend({
-  units: service(),
+export default class extends BaseHelper {
+  @service units;
 
   format(value, options) {
     return this.units.formatLift(value, options);
-  },
-});
+  }
+}

--- a/ember/app/helpers/format-lift.js
+++ b/ember/app/helpers/format-lift.js
@@ -1,10 +1,11 @@
-import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-export default Helper.extend({
+import BaseHelper from 'ember-intl/helpers/-format-base';
+
+export default BaseHelper.extend({
   units: service(),
 
-  compute([value], options) {
+  format(value, options) {
     return this.units.formatLift(value, options);
   },
 });

--- a/ember/app/helpers/format-speed.js
+++ b/ember/app/helpers/format-speed.js
@@ -1,10 +1,11 @@
-import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-export default Helper.extend({
+import BaseHelper from 'ember-intl/helpers/-format-base';
+
+export default BaseHelper.extend({
   units: service(),
 
-  compute([value], options) {
+  format(value, options) {
     return this.units.formatSpeed(value, options);
   },
 });

--- a/ember/app/helpers/format-speed.js
+++ b/ember/app/helpers/format-speed.js
@@ -1,13 +1,8 @@
 import Helper from '@ember/component/helper';
-import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Helper.extend({
   units: service(),
-
-  speedUnitObserver: observer('units.speedUnit', function () {
-    this.recompute();
-  }),
 
   compute([value], options) {
     return this.units.formatSpeed(value, options);

--- a/ember/app/helpers/format-speed.js
+++ b/ember/app/helpers/format-speed.js
@@ -2,10 +2,10 @@ import { inject as service } from '@ember/service';
 
 import BaseHelper from 'ember-intl/helpers/-format-base';
 
-export default BaseHelper.extend({
-  units: service(),
+export default class extends BaseHelper {
+  @service units;
 
   format(value, options) {
     return this.units.formatSpeed(value, options);
-  },
-});
+  }
+}

--- a/ember/tests/helpers/format-altitude-test.js
+++ b/ember/tests/helpers/format-altitude-test.js
@@ -1,0 +1,56 @@
+import { render, settled } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+module('Helper | format-altitude', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns a formatted altitude value', async function (assert) {
+    this.set('altitude', 1234);
+
+    await render(hbs`{{format-altitude altitude}}`);
+    assert.dom().hasText('1,234 m');
+
+    this.set('altitude', 2345);
+    await settled();
+    assert.dom().hasText('2,345 m');
+  });
+
+  test('supports a `decimals` option', async function (assert) {
+    this.set('altitude', 1234);
+
+    await render(hbs`{{format-altitude altitude decimals=2}}`);
+    assert.dom().hasText('1,234.00 m');
+  });
+
+  test('supports a `withUnit` option', async function (assert) {
+    this.set('altitude', 1234);
+
+    await render(hbs`{{format-altitude altitude withUnit=false}}`);
+    assert.dom().hasText('1,234');
+  });
+
+  test('changing the unit invalidates the value', async function (assert) {
+    this.set('altitude', 1234);
+
+    await render(hbs`{{format-altitude altitude}}`);
+    assert.dom().hasText('1,234 m');
+
+    this.owner.lookup('service:units').altitudeUnit = 'ft';
+    await settled();
+    assert.dom().hasText('4,049 ft');
+  });
+
+  test('changing the locale invalidates the value', async function (assert) {
+    this.set('altitude', 1234);
+
+    await render(hbs`{{format-altitude altitude}}`);
+    assert.dom().hasText('1,234 m');
+
+    this.owner.lookup('service:intl').setLocale('de');
+    await settled();
+    assert.dom().hasText('1.234 m');
+  });
+});

--- a/ember/tests/helpers/format-distance-test.js
+++ b/ember/tests/helpers/format-distance-test.js
@@ -1,0 +1,56 @@
+import { render, settled } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test, skip } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+module('Helper | format-distance', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns a formatted distance value', async function (assert) {
+    this.set('distance', 42024);
+
+    await render(hbs`{{format-distance distance}}`);
+    assert.dom().hasText('42 km');
+
+    this.set('distance', 123456);
+    await settled();
+    assert.dom().hasText('123 km');
+  });
+
+  test('supports a `decimals` option', async function (assert) {
+    this.set('distance', 42024);
+
+    await render(hbs`{{format-distance distance decimals=2}}`);
+    assert.dom().hasText('42.02 km');
+  });
+
+  test('supports a `withUnit` option', async function (assert) {
+    this.set('distance', 42024);
+
+    await render(hbs`{{format-distance distance withUnit=false}}`);
+    assert.dom().hasText('42');
+  });
+
+  test('changing the unit invalidates the value', async function (assert) {
+    this.set('distance', 42024);
+
+    await render(hbs`{{format-distance distance}}`);
+    assert.dom().hasText('42 km');
+
+    this.owner.lookup('service:units').distanceUnit = 'NM';
+    await settled();
+    assert.dom().hasText('23 NM');
+  });
+
+  skip('changing the locale invalidates the value', async function (assert) {
+    this.set('distance', 42024);
+
+    await render(hbs`{{format-distance distance decimals=1}}`);
+    assert.dom().hasText('42.0 km');
+
+    this.owner.lookup('service:intl').setLocale('de');
+    await settled();
+    assert.dom().hasText('42,0 km');
+  });
+});

--- a/ember/tests/helpers/format-distance-test.js
+++ b/ember/tests/helpers/format-distance-test.js
@@ -1,6 +1,6 @@
 import { render, settled } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import hbs from 'htmlbars-inline-precompile';
 
@@ -43,7 +43,7 @@ module('Helper | format-distance', function (hooks) {
     assert.dom().hasText('23 NM');
   });
 
-  skip('changing the locale invalidates the value', async function (assert) {
+  test('changing the locale invalidates the value', async function (assert) {
     this.set('distance', 42024);
 
     await render(hbs`{{format-distance distance decimals=1}}`);

--- a/ember/tests/helpers/format-lift-test.js
+++ b/ember/tests/helpers/format-lift-test.js
@@ -1,0 +1,56 @@
+import { render, settled } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+module('Helper | format-lift', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns a formatted lift value', async function (assert) {
+    this.set('lift', 4.2);
+
+    await render(hbs`{{format-lift lift}}`);
+    assert.dom().hasText('4.2 m/s');
+
+    this.set('lift', 1.54);
+    await settled();
+    assert.dom().hasText('1.5 m/s');
+  });
+
+  test('supports a `decimals` option', async function (assert) {
+    this.set('lift', 4.2);
+
+    await render(hbs`{{format-lift lift decimals=2}}`);
+    assert.dom().hasText('4.20 m/s');
+  });
+
+  test('supports a `withUnit` option', async function (assert) {
+    this.set('lift', 4.2);
+
+    await render(hbs`{{format-lift lift withUnit=false}}`);
+    assert.dom().hasText('4.2');
+  });
+
+  test('changing the unit invalidates the value', async function (assert) {
+    this.set('lift', 4.2);
+
+    await render(hbs`{{format-lift lift}}`);
+    assert.dom().hasText('4.2 m/s');
+
+    this.owner.lookup('service:units').liftUnit = 'ft/min';
+    await settled();
+    assert.dom().hasText('827 ft/min');
+  });
+
+  test('changing the locale invalidates the value', async function (assert) {
+    this.set('lift', 4.2);
+
+    await render(hbs`{{format-lift lift}}`);
+    assert.dom().hasText('4.2 m/s');
+
+    this.owner.lookup('service:intl').setLocale('de');
+    await settled();
+    assert.dom().hasText('4,2 m/s');
+  });
+});

--- a/ember/tests/helpers/format-speed-test.js
+++ b/ember/tests/helpers/format-speed-test.js
@@ -1,0 +1,56 @@
+import { render, settled } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+module('Helper | format-speed', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns a formatted speed value', async function (assert) {
+    this.set('speed', 33.76);
+
+    await render(hbs`{{format-speed speed}}`);
+    assert.dom().hasText('121.5 km/h');
+
+    this.set('speed', 54.1);
+    await settled();
+    assert.dom().hasText('194.8 km/h');
+  });
+
+  test('supports a `decimals` option', async function (assert) {
+    this.set('speed', 33.76);
+
+    await render(hbs`{{format-speed speed decimals=2}}`);
+    assert.dom().hasText('121.54 km/h');
+  });
+
+  test('supports a `withUnit` option', async function (assert) {
+    this.set('speed', 33.76);
+
+    await render(hbs`{{format-speed speed withUnit=false}}`);
+    assert.dom().hasText('121.5');
+  });
+
+  test('changing the unit invalidates the value', async function (assert) {
+    this.set('speed', 33.76);
+
+    await render(hbs`{{format-speed speed}}`);
+    assert.dom().hasText('121.5 km/h');
+
+    this.owner.lookup('service:units').speedUnit = 'm/s';
+    await settled();
+    assert.dom().hasText('33.8 m/s');
+  });
+
+  test('changing the locale invalidates the value', async function (assert) {
+    this.set('speed', 33.76);
+
+    await render(hbs`{{format-speed speed}}`);
+    assert.dom().hasText('121.5 km/h');
+
+    this.owner.lookup('service:intl').setLocale('de');
+    await settled();
+    assert.dom().hasText('121,5 km/h');
+  });
+});

--- a/ember/tests/services/units-test.js
+++ b/ember/tests/services/units-test.js
@@ -1,0 +1,92 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Service | units', function (hooks) {
+  setupTest(hooks);
+
+  test('setting unit index changes the unit', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.distanceUnit, 'km');
+    assert.equal(units.speedUnit, 'km/h');
+    assert.equal(units.liftUnit, 'm/s');
+    assert.equal(units.altitudeUnit, 'm');
+
+    units.distanceUnitIndex = 2;
+    units.speedUnitIndex = 3;
+    units.liftUnitIndex = 2;
+    units.altitudeUnitIndex = 1;
+
+    assert.equal(units.distanceUnit, 'NM');
+    assert.equal(units.speedUnit, 'mph');
+    assert.equal(units.liftUnit, 'ft/min');
+    assert.equal(units.altitudeUnit, 'ft');
+  });
+
+  test('setting unit changes the unit index', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.distanceUnitIndex, 1);
+    assert.equal(units.speedUnitIndex, 1);
+    assert.equal(units.liftUnitIndex, 0);
+    assert.equal(units.altitudeUnitIndex, 0);
+
+    units.distanceUnit = 'NM';
+    units.speedUnit = 'mph';
+    units.liftUnit = 'ft/min';
+    units.altitudeUnit = 'ft';
+
+    assert.equal(units.distanceUnitIndex, 2);
+    assert.equal(units.speedUnitIndex, 3);
+    assert.equal(units.liftUnitIndex, 2);
+    assert.equal(units.altitudeUnitIndex, 1);
+  });
+
+  test('formatDistance()', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.formatDistance(1234567), '1,235 km');
+
+    units.distanceUnitIndex = 0;
+    assert.equal(units.formatDistance(1234567), '1,234,567 m');
+
+    units.distanceUnitIndex = 2;
+    assert.equal(units.formatDistance(1234567), '667 NM');
+  });
+
+  test('formatSpeed()', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.formatSpeed(123), '442.8 km/h');
+
+    units.speedUnitIndex = 0;
+    assert.equal(units.formatSpeed(123), '123.0 m/s');
+
+    units.speedUnitIndex = 2;
+    assert.equal(units.formatSpeed(123), '239.1 kt');
+  });
+
+  test('formatLift()', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.formatLift(4.2), '4.2 m/s');
+
+    units.liftUnitIndex = 1;
+    assert.equal(units.formatLift(4.2), '8.2 kt');
+  });
+
+  test('formatAltitude()', function (assert) {
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.formatAltitude(1234), '1,234 m');
+
+    units.altitudeUnitIndex = 1;
+    assert.equal(units.formatAltitude(1234), '4,049 ft');
+  });
+
+  test('formatted values depend on the locale', function (assert) {
+    let intl = this.owner.lookup('service:intl');
+
+    intl.setLocale('en');
+
+    let units = this.owner.lookup('service:units');
+    assert.equal(units.formatAltitude(1234), '1,234 m');
+
+    intl.setLocale('de');
+    assert.equal(units.formatAltitude(1234), '1.234 m');
+  });
+});


### PR DESCRIPTION
This PR adds tests for the `units` service and the corresponding `format-distance|altitude|lift|speed` helpers, it removes the obsolete `observer` from these helpers and ensures that they invalidate their values when the locale changes.