### PR TITLE
map-click-handler: Use `setPosition()` after adding overlay to the map

### DIFF
--- a/ember/app/components/map-click-handler.js
+++ b/ember/app/components/map-click-handler.js
@@ -35,8 +35,11 @@ export default class MapClickHandler extends Component {
   }
 
   @action addOverlay(element) {
-    this.overlay = new Overlay({ element, position: this.overlayPosition });
+    this.overlay = new Overlay({ element });
     this.args.map.addOverlay(this.overlay);
+
+    // see https://github.com/openlayers/ol-cesium/issues/679
+    this.overlay.setPosition(this.overlayPosition);
   }
 
   @action removeOverlay() {


### PR DESCRIPTION
This should hopefully work around https://github.com/skylines-project/skylines/issues/2068 for now