### PR TITLE
renovate: Disable `python` language

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,9 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["npm"],
+  "python": {
+    "enabled": false
+  },
   "rangeStrategy": "bump",
   "semanticCommits": false,
   "postUpdateOptions": ["yarnDedupeHighest"]


### PR DESCRIPTION
Instead of disabling all managers except `npm`