### PR TITLE
dependency-lint: Disable test generation

### DIFF
--- a/ember/config/dependency-lint.js
+++ b/ember/config/dependency-lint.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  generateTests: false,
+};


### PR DESCRIPTION
We run lint on CI, there is no need to slow down the build process by generating tests