### PR TITLE
Use `docker-compose` setup to fix CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.cache/
+.coverage
+.envrc
+.git/
+.github/
+.idea/
+.local/
+.vagrant/
+ember/node_modules/
+htdocs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,49 +74,14 @@ jobs:
       matrix:
         python-version: [2.7, 3.6]
 
-    services:
-      postgres:
-        image: postgis/postgis:10-2.5
-        env:
-          POSTGRES_DB: skylines_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      redis:
-        image: redis
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
-
-    env:
-      PGHOST: localhost
-      PGUSER: postgres
-      PGPASSWORD: postgres
-
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
 
-      # Install Python dependencies
-      - run: pip install pipenv==v2020.4.1b2
-      - run: pipenv install --dev
+      # Build Docker images
+      - run: docker-compose build --build-arg PYTHON_VERSION=${{ matrix.python-version }}
 
       # Run the test suite
-      - run: pipenv run py.test -vv --color=yes --cov=skylines --cov-report term-missing:skip-covered
+      - run: docker-compose run api pipenv run py.test -vv --color=yes --cov=skylines --cov-report term-missing:skip-covered
 
   backend-lint:
     name: Backend (Lint)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use Python 2.7 by default, but allow
+# e.g. `--build-arg PYTHON_VERSION=3.6` usage
+ARG PYTHON_VERSION=2.7
+FROM python:${PYTHON_VERSION}
+
+RUN pip install --upgrade pip
+RUN pip install pipenv==v2020.11.15
+
+WORKDIR /home/skylines/code/
+
+# Install Python dependencies
+COPY Pipfile Pipfile.lock /home/skylines/code/
+RUN pipenv install --dev --python=${PYTHON_VERSION}
+
+# Run the development server by default
+CMD ["pipenv", "run", "./manage.py", "runserver"]

--- a/config/default.py
+++ b/config/default.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import os.path
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -44,8 +45,8 @@ SKYLINES_LISTS_DISPLAY_LENGTH = 50
 
 SKYLINES_MAP_TILE_URL = "https://www.skylines.aero/mapproxy"
 
-BROKER_URL = "redis://localhost:6379/0"
-CELERY_RESULT_BACKEND = "redis://localhost:6379/0"
+BROKER_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 CELERYD_LOG_LEVEL = "INFO"
 
 # limits for AnalyseFlight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+
+volumes:
+  postgres_data:
+
+services:
+  db:
+    image: postgis/postgis:10-2.5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: skylines_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 5s
+
+  redis:
+    image: redis
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: redis-cli ping
+      interval: 5s
+
+  api:
+    build: .
+    environment:
+      PGHOST: db
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - 5000:5000
+    volumes:
+      - .:/home/skylines/code/
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy


### PR DESCRIPTION
This Docker-based setup will hopefully make it a bit more straight-forward in the future to have the same thing running locally as in CI.

Please note that this is currently primarily targeted at working for CI. For local development a few adjustments are still needed, like for example using a different database name.