### PR TITLE
commands.tracking.generate_through_daemon: Add `--host/port` options

### DIFF
--- a/skylines/commands/tracking/generate_through_daemon.py
+++ b/skylines/commands/tracking/generate_through_daemon.py
@@ -23,13 +23,13 @@ from time import sleep
 class GenerateThroughDaemon(Command):
     """ Generate fake live tracks for debugging on daemon """
 
-    UDP_IP = "127.0.0.1"
-    UDP_PORT = 5597
-    ADDRESS = (UDP_IP, UDP_PORT)
+    option_list = (
+        Option("--host", type=str, default="127.0.0.1"),
+        Option("--port", type=int, default=5597),
+        Option("user_id", type=int, help="a user ID"),
+    )
 
-    option_list = (Option("user_id", type=int, help="a user ID"),)
-
-    def run(self, user_id):
+    def run(self, user_id, **kwargs):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         user = User.get(user_id)
@@ -79,7 +79,7 @@ class GenerateThroughDaemon(Command):
                 0,
             )
             data = set_crc(data)
-            sock.sendto(data, self.ADDRESS)
+            sock.sendto(data, (kwargs.get("host"), kwargs.get("port")))
 
             print(".", end="")
             sys.stdout.flush()


### PR DESCRIPTION
This will allow us to use `./manage.py tracking generate_through_daemon --host tracking 42` once there is a `tracking` Docker service.