### PR TITLE
 Docker: Add `worker` service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,22 @@ version: '3.9'
 volumes:
   postgres_data:
 
+x-api: &api
+  build: .
+  environment:
+    PGHOST: db
+    PGUSER: postgres
+    PGPASSWORD: postgres
+    REDIS_URL: redis://redis:6379/0
+  volumes:
+    - .:/home/skylines/code/
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+
+
 services:
   db:
     image: postgis/postgis:10-2.5
@@ -27,18 +43,6 @@ services:
       interval: 5s
 
   api:
-    build: .
-    environment:
-      PGHOST: db
-      PGUSER: postgres
-      PGPASSWORD: postgres
-      REDIS_URL: redis://redis:6379/0
+    <<: *api
     ports:
       - 5000:5000
-    volumes:
-      - .:/home/skylines/code/
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
 x-api: &api
   build: .
   environment:
+    C_FORCE_ROOT: "1"
     PGHOST: db
     PGUSER: postgres
     PGPASSWORD: postgres
@@ -46,3 +47,8 @@ services:
     <<: *api
     ports:
       - 5000:5000
+
+  worker:
+    <<: *api
+    command: pipenv run ./manage.py celery runworker
+


### PR DESCRIPTION
This PR adds a `worker` service to the `docker-compose.yml` file, which runs our Celery-based task queue.