### PR TITLE
Docker: Add `tracking` service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,3 +52,8 @@ services:
     <<: *api
     command: pipenv run ./manage.py celery runworker
 
+  tracking:
+    <<: *api
+    command: pipenv run ./manage.py tracking runserver
+    ports:
+      - 5597:5597/udp

--- a/skylines/commands/tracking/server.py
+++ b/skylines/commands/tracking/server.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import sys
 from flask_script import Command
 
 from skylines.app import create_app
@@ -11,6 +12,7 @@ class Server(Command):
 
     def run(self):
         print("Receiving datagrams on :5597")
+        sys.stdout.flush()
         server = TrackingServer(":5597")
         server.init_app(create_app())
         server.serve_forever()


### PR DESCRIPTION
This PR adds another service to the docker-compose setup, which runs our Live Tracking server and exposes it on the UDP port 5597 on the host machine.

To generate test data through that server you can use:

```
docker-compose run api pipenv run ./manage.py tracking generate-through-daemon --host tracking 1
```