### PR TITLE
UploadFlightForm: Disable pilot selection while uploading

### DIFF
--- a/ember/app/components/pilot-select.hbs
+++ b/ember/app/components/pilot-select.hbs
@@ -1,4 +1,10 @@
-<PowerSelect @options={{pilots}} @selected={{pilot}} @onChange={{action "onChange"}} @searchField="name" as |pilot|>
+<PowerSelect
+  @options={{pilots}}
+  @disabled={{@disabled}}
+  @selected={{pilot}}
+  @onChange={{action "onChange"}}
+  @searchField="name"
+as |pilot|>
   {{#if (eq pilot.id null)}}
     [{{t "unknown-or-other-person"}}]
   {{else}}

--- a/ember/app/components/upload-flight-form.hbs
+++ b/ember/app/components/upload-flight-form.hbs
@@ -1,5 +1,8 @@
 <div class="panel-body" ...attributes>
-  <form {{on "submit" (action "submit")}}>
+  <form
+    data-test-upload-form={{if uploadTask.isRunning "uploading"}}
+    {{on "submit" (action "submit")}}
+  >
     {{#if error}}
       <BsAlert @type="danger" @dismissible={{false}}>{{error}}</BsAlert>
     {{/if}}
@@ -16,7 +19,12 @@
       >
     </ValidatedBlock>
 
-    <ValidatedBlock @label={{t "pilot"}} @validation={{validations.attrs.pilotId}} @didValidate={{didValidate}}>
+    <ValidatedBlock
+      @label={{t "pilot"}}
+      @validation={{validations.attrs.pilotId}}
+      @didValidate={{didValidate}}
+      data-test-pilot
+    >
       <PilotSelect
         @clubMembers={{clubMembers}}
         @pilotId={{pilotId}}

--- a/ember/app/components/upload-flight-form.hbs
+++ b/ember/app/components/upload-flight-form.hbs
@@ -17,7 +17,12 @@
     </ValidatedBlock>
 
     <ValidatedBlock @label={{t "pilot"}} @validation={{validations.attrs.pilotId}} @didValidate={{didValidate}}>
-      <PilotSelect @clubMembers={{clubMembers}} @pilotId={{pilotId}} @onChange={{action (mut pilotId)}} />
+      <PilotSelect
+        @clubMembers={{clubMembers}}
+        @pilotId={{pilotId}}
+        @disabled={{uploadTask.isRunning}}
+        @onChange={{action (mut pilotId)}}
+      />
     </ValidatedBlock>
 
     {{#if showPilotNameInput}}


### PR DESCRIPTION
During flight upload the pilot selection field was previously not disabled. This PR fixes the issue and adjusts the existing upload test to check for this too.