### PR TITLE
FixTable: Fix `@onRemove` assignment

### DIFF
--- a/ember/app/components/fix-table.hbs
+++ b/ember/app/components/fix-table.hbs
@@ -6,7 +6,7 @@
         @selectable={{this.selectable}}
         @selected={{and this.selectable (eq row.id @selection)}}
         @onSelect={{this.select}}
-        @onRemove={{this.onRemove}} />
+        @onRemove={{@onRemove}} />
     {{/each}}
   </tbody>
 </table>


### PR DESCRIPTION
`this.onRemove` does not exist on the JS class, which was causing errors