### PR TITLE
Add `upload_to_weglide` worker task

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,6 +34,7 @@ requests-oauthlib = ">=0.6.2,<1.2.0"  # see https://github.com/lepture/flask-oau
 sentry-sdk = {extras = ["flask"],version = "==0.12.3"}
 mapproxy = "*"
 gunicorn = "*"
+requests = "==2.22.0"
 
 [dev-packages]
 fabric = "==1.14.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ae2f93f06feb6704e39685bb0099d18a9f0e99e6b4bcb85570165df1e5add87d"
+            "sha256": "96b54e09fe82d28d3fc0d5faa8b7096f74d72d98be9c231001225705b4c67034"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/migrations/versions/58325345d375_add_weglide_fields_to_igcfile.py
+++ b/migrations/versions/58325345d375_add_weglide_fields_to_igcfile.py
@@ -1,0 +1,17 @@
+# revision identifiers, used by Alembic.
+revision = "58325345d375"
+down_revision = "70a6f5e6f0e1"
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+def upgrade():
+    op.add_column("igc_files", sa.Column("weglide_data", JSONB(), nullable=True))
+    op.add_column("igc_files", sa.Column("weglide_status", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("igc_files", "weglide_status")
+    op.drop_column("igc_files", "weglide_data")

--- a/skylines/model/igcfile.py
+++ b/skylines/model/igcfile.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from sqlalchemy.sql.expression import and_
 from sqlalchemy.types import Integer, DateTime, String, Unicode, Date
+from sqlalchemy.dialects.postgresql import JSONB
 
 from skylines.database import db
 from skylines.lib import files
@@ -32,6 +33,15 @@ class IGCFile(db.Model):
     model = db.Column(Unicode(64))
 
     date_utc = db.Column(Date, nullable=False)
+
+    # WeGlide API response HTTP status code,
+    # or None (no upload requested)
+    # or 1 (upload in progress),
+    # or 2 (generic error),
+    weglide_status = db.Column(Integer)
+
+    # WeGlide API response JSON payload, or `null`
+    weglide_data = db.Column(JSONB)
 
     def __repr__(self):
         return unicode_to_str(

--- a/skylines/schemas/schemas.py
+++ b/skylines/schemas/schemas.py
@@ -263,6 +263,8 @@ class FlightUploadSchema(Schema):
         allow_none=True,
         validate=validate.Length(max=255),
     )
+    weglideBirthday = fields.Date()
+    weglideUserId = fields.Integer()
 
     @pre_load
     def pre_load(self, in_data, **kwargs):
@@ -271,6 +273,10 @@ class FlightUploadSchema(Schema):
             del data["pilotId"]
         if data.get("pilotName") == "":
             del data["pilotName"]
+        if data.get("weglideBirthday") == "":
+            del data["weglideBirthday"]
+        if data.get("weglideUserId") == "":
+            del data["weglideUserId"]
 
         if not data.get("pilotId") and not data.get("pilotName"):
             raise ValidationError("Either pilotName or pilotId must be set")

--- a/skylines/weglide.py
+++ b/skylines/weglide.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import requests
+import sentry_sdk
+
+from skylines.database import db
+from skylines.lib.files import open_file
+from skylines.model import IGCFile
+
+log = logging.getLogger(__name__)
+
+
+def upload(igc_file_id, weglide_user_id, weglide_birthday):
+    with sentry_sdk.push_scope() as scope:
+        scope.set_context(
+            "WeGlide Upload",
+            {
+                "igc_file_id": igc_file_id,
+                "weglide_user_id": weglide_user_id,
+            },
+        )
+
+        log.info(
+            "Uploading IGC file %s to WeGlide for user %s…",
+            igc_file_id,
+            weglide_user_id,
+        )
+
+        igc_file = db.session.query(IGCFile).get(igc_file_id)
+        if not igc_file:
+            # missing IGCFile in the database is logged and sent to Sentry
+            log.warn(
+                "IGC file (%s) upload failed because it can not be found in the database",
+                igc_file_id,
+            )
+            sentry_sdk.capture_message(
+                "IGC file can not be found in the database", "warn"
+            )
+            return False
+
+        try:
+            with open_file(igc_file.filename) as f:
+                data = {"user_id": weglide_user_id, "date_of_birth": weglide_birthday}
+                files = {"file": (igc_file.filename, f)}
+
+                response = requests.post(
+                    "https://api.weglide.org/v1/igcfile",
+                    data=data,
+                    files=files,
+                    timeout=30,
+                )
+
+                igc_file.weglide_status = response.status_code
+                try:
+                    igc_file.weglide_data = response.json()
+                except ValueError:
+                    # `igc_file.weglide_data` is already `None` so we don't have to do anything
+                    pass
+
+                db.session.commit()
+
+                if 200 <= response.status_code < 300:
+                    log.info("%s: WeGlide IGC file upload successful", igc_file)
+                else:
+                    log.warn(
+                        "%s: WeGlide IGC file upload failed (HTTP %d)",
+                        igc_file,
+                        response.status_code,
+                    )
+
+                return True
+
+        except requests.exceptions.RequestException:
+            # network errors are an expected failure so we only log them as warnings and move on... 🤷‍
+            log.warn("%s: WeGlide IGC file upload failed", igc_file, exc_info=True)
+
+        except Exception:
+            # unexpected errors are logged and sent to Sentry
+            log.error("%s: WeGlide IGC file upload failed", igc_file, exc_info=True)
+            sentry_sdk.capture_exception()
+
+        igc_file.weglide_status = 2
+        db.session.commit()

--- a/skylines/worker/tasks.py
+++ b/skylines/worker/tasks.py
@@ -56,3 +56,10 @@ def find_meetings(flight_id):
             )
 
     db.session.commit()
+
+
+@celery.task
+def upload_to_weglide(igc_file_id, weglide_user_id, weglide_birthday):
+    from skylines import weglide
+
+    weglide.upload(igc_file_id, weglide_user_id, weglide_birthday)

--- a/tests/schemas/schemas/test_flight_upload.py
+++ b/tests/schemas/schemas/test_flight_upload.py
@@ -1,3 +1,4 @@
+from datetime import date
 import pytest
 
 from skylines.schemas import FlightUploadSchema
@@ -53,4 +54,60 @@ def test_empty_pilot_name(schema):
 def test_pilot_id_and_name(schema):
     data, errors = schema.load({"pilotId": 123, "pilotName": "JD"})
     assert data == {"pilot_id": 123}
+    assert errors == {}
+
+
+def test_with_weglide(schema):
+    data, errors = schema.load(
+        {"pilotId": 123, "weglideUserId": 123, "weglideBirthday": "2020-01-01"}
+    )
+    assert data == {
+        "pilot_id": 123,
+        "weglideUserId": 123,
+        "weglideBirthday": date(2020, 1, 1),
+    }
+    assert errors == {}
+
+
+def test_weglide_with_broken_id(schema):
+    data, errors = schema.load(
+        {"pilotId": 123, "weglideUserId": "foo", "weglideBirthday": "2020-01-01"}
+    )
+    assert data == {"pilot_id": 123, "weglideBirthday": date(2020, 1, 1)}
+    assert errors == {"weglideUserId": [u"Not a valid integer."]}
+
+
+def test_weglide_with_missing_id(schema):
+    data, errors = schema.load({"pilotId": 123, "weglideBirthday": "2020-01-01"})
+    assert data == {"pilot_id": 123, "weglideBirthday": date(2020, 1, 1)}
+    assert errors == {}
+
+
+def test_weglide_with_empty_id(schema):
+    data, errors = schema.load(
+        {"pilotId": 123, "weglideUserId": "", "weglideBirthday": "2020-01-01"}
+    )
+    assert data == {"pilot_id": 123, "weglideBirthday": date(2020, 1, 1)}
+    assert errors == {}
+
+
+def test_weglide_with_broken_birthday(schema):
+    data, errors = schema.load(
+        {"pilotId": 123, "weglideUserId": 123, "weglideBirthday": "2abc-01-01"}
+    )
+    assert data == {"pilot_id": 123, "weglideUserId": 123}
+    assert errors == {"weglideBirthday": [u"Not a valid date."]}
+
+
+def test_weglide_with_missing_birthday(schema):
+    data, errors = schema.load({"pilotId": 123, "weglideUserId": 123})
+    assert data == {"pilot_id": 123, "weglideUserId": 123}
+    assert errors == {}
+
+
+def test_weglide_with_empty_birthday(schema):
+    data, errors = schema.load(
+        {"pilotId": 123, "weglideUserId": 123, "weglideBirthday": ""}
+    )
+    assert data == {"pilot_id": 123, "weglideUserId": 123}
     assert errors == {}

--- a/tests/weglide/upload_test.py
+++ b/tests/weglide/upload_test.py
@@ -1,0 +1,126 @@
+import pytest
+import requests
+from mock import patch, Mock
+from shutil import copyfile
+
+from skylines.lib import files
+from skylines.model import IGCFile
+from skylines import weglide
+
+from tests.data import users, igcs
+
+
+@pytest.fixture
+def test_data(db_session):
+    # create test user
+    john = users.john()
+    db_session.add(john)
+
+    # create IGC file
+    igc_file = igcs.simple(john)
+    igc_file.weglide_status = 1
+    db_session.add(igc_file)
+
+    path = files.filename_to_path(igc_file.filename)
+    copyfile(igcs.simple_path, path)
+
+    db_session.flush()
+
+    return (john, igc_file)
+
+
+def test_happy_path(db_session, test_data):
+    (_, igc_file) = test_data
+
+    response = [
+        {
+            "id": 42,
+            "user": {"id": 123, "name": "John Doe"},
+            "igc_file": {
+                "id": 999,
+                "file": "123/igcfiles/foo.igc",
+            },
+        }
+    ]
+
+    with patch("requests.post") as mock:
+        mock.return_value.status_code = 201
+        mock.return_value.json = Mock()
+        mock.return_value.json.return_value = response
+
+        weglide.upload(igc_file.id, "123", "2020-01-07")
+
+    mock.assert_called_once()
+    assert mock.call_args.args == ("https://api.weglide.org/v1/igcfile",)
+    assert mock.call_args.kwargs.get("data") == {
+        "user_id": "123",
+        "date_of_birth": "2020-01-07",
+    }
+    assert mock.call_args.kwargs.get("files")
+
+    igc_file = db_session.query(IGCFile).get(igc_file.id)
+    assert igc_file.weglide_status == 201
+    assert igc_file.weglide_data == response
+
+
+def test_failure_with_missing_database_record():
+    with patch("requests.post") as mock:
+        weglide.upload(42, "239", "1987-02-24")
+
+    mock.assert_not_called()
+
+
+def test_with_422_json_error(db_session, test_data):
+    (_, igc_file) = test_data
+
+    with patch("requests.post") as mock:
+        mock.return_value.status_code = 500
+        mock.return_value.json = Mock()
+        mock.return_value.json.return_value = {"details": "foo"}
+
+        weglide.upload(igc_file.id, "123", "2020-01-07")
+
+    igc_file = db_session.query(IGCFile).get(igc_file.id)
+    assert igc_file.weglide_status == 500
+    assert igc_file.weglide_data == {"details": "foo"}
+
+
+def test_with_500_non_json_error(db_session, test_data):
+    (_, igc_file) = test_data
+
+    with patch("requests.post") as mock:
+        mock.return_value.status_code = 500
+        mock.return_value.json = Mock()
+        mock.return_value.json.side_effect = ValueError("Boom!")
+
+        weglide.upload(igc_file.id, "123", "2020-01-07")
+
+    igc_file = db_session.query(IGCFile).get(igc_file.id)
+    assert igc_file.weglide_status == 500
+    assert igc_file.weglide_data is None
+
+
+def test_with_network_error(db_session, test_data):
+    (_, igc_file) = test_data
+
+    with patch("requests.post") as mock:
+        mock.side_effect = requests.exceptions.ConnectionError()
+
+        weglide.upload(igc_file.id, "123", "2020-01-07")
+
+    igc_file = db_session.query(IGCFile).get(igc_file.id)
+    assert igc_file.weglide_status == 2
+    assert igc_file.weglide_data is None
+
+
+def test_with_generic_error(db_session, test_data):
+    (_, igc_file) = test_data
+
+    with patch("requests.post") as mock:
+        mock.side_effect = Exception("Boom!")
+
+        weglide.upload(igc_file.id, "123", "2020-01-07")
+
+    igc_file = db_session.query(IGCFile).get(igc_file.id)
+    assert igc_file.weglide_status == 2
+    assert igc_file.weglide_data is None


### PR DESCRIPTION
This PR adds a `upload_to_weglide` worker task based on Celery, that receives an IGC file ID, a WeGlide user ID and a birthdate, and then calls the WeGlide API to upload the IGC file over there. This task is automatically queued up when upload API request contains the `weglideUserId` and `weglideBirthday` fields. The result of the API call is saved in the new `weglide_status` and `weglide_data` fields on the `IGCFile` model and will be serialized on the API in a follow-up PR.

This addresses the first part of #2339 