### PR TITLE
IGCFile: Expose WeGlide fields on the API

### DIFF
--- a/skylines/schemas/schemas.py
+++ b/skylines/schemas/schemas.py
@@ -160,6 +160,9 @@ class IGCFileSchema(Schema):
 
     date = fields.Date(attribute="date_utc")
 
+    weglideStatus = fields.Integer(attribute="weglide_status")
+    weglideData = fields.Raw(attribute="weglide_data")
+
     class Meta(Schema.Meta):
         load_only = ("ownerId",)
         dump_only = ("owner",)
@@ -230,7 +233,16 @@ class FlightSchema(Schema):
     igcFile = fields.Nested(
         IGCFileSchema,
         attribute="igc_file",
-        only=("owner", "filename", "registration", "competitionId", "model", "date"),
+        only=(
+            "owner",
+            "filename",
+            "registration",
+            "competitionId",
+            "model",
+            "date",
+            "weglideStatus",
+            "weglideData",
+        ),
     )
 
     class Meta(Schema.Meta):

--- a/tests/api/views/flights/read_test.py
+++ b/tests/api/views/flights/read_test.py
@@ -53,6 +53,8 @@ def expected_basic_flight_json(flight):
             u"competitionId": None,
             u"model": None,
             u"date": u"2011-06-18",
+            u"weglideStatus": None,
+            u"weglideData": None,
         },
     }
 
@@ -177,6 +179,8 @@ def test_filled_flight(db_session, client):
                 u"competitionId": u"TH",
                 u"model": u"Hornet",
                 u"date": u"2017-01-15",
+                u"weglideStatus": None,
+                u"weglideData": None,
             },
         }
     }
@@ -269,6 +273,8 @@ def test_meetings(db_session, client):
                         },
                         u"model": None,
                         u"competitionId": None,
+                        u"weglideStatus": None,
+                        u"weglideData": None,
                     },
                 },
                 u"times": [

--- a/tests/api/views/flights/upload_test.py
+++ b/tests/api/views/flights/upload_test.py
@@ -61,6 +61,8 @@ def test_upload(db_session, client):
                                 u"registration": u"LY-KDR",
                                 u"competitionId": None,
                                 u"filename": Match(r"simple(_\d+)?.igc"),
+                                u"weglideStatus": None,
+                                u"weglideData": None,
                             },
                             u"landingAirport": None,
                             u"triangleDistance": 4003,
@@ -299,7 +301,12 @@ def test_upload_with_weglide(db_session, client):
                                 u"copilot": None,
                                 u"copilotName": None,
                                 u"distance": 7872,
-                                u"igcFile": dict,
+                                u"igcFile": Partial(
+                                    {
+                                        u"weglideStatus": 1,
+                                        u"weglideData": None,
+                                    }
+                                ),
                                 u"pilotName": None,
                                 u"pilot": {
                                     u"id": john.id,


### PR DESCRIPTION
This PR implements part two of #2339 by exposing the two new IGC file fields on the API