### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ember/app/sentry.js
+++ b/ember/app/sentry.js
@@ -17,7 +17,7 @@ export function startSentry() {
       let error = hint.originalException;
 
       if (error) {
-        // ignore cancelation errors from the Ember router of ember-concurrency
+        // ignore cancellation errors from the Ember router of ember-concurrency
         if (error.name === 'TaskCancelation' || error.name === 'TransitionAborted') {
           return null;
         }

--- a/skylines/api/views/flights.py
+++ b/skylines/api/views/flights.py
@@ -292,7 +292,7 @@ def _reanalyse_if_needed(flight):
             tasks.analyse_flight.delay(flight.id)
         except ConnectionError:
             current_app.logger.info("Cannot connect to Redis server")
-            # analyse syncronously...
+            # analyse synchronously...
             analyse_flight(flight)
             db.session.commit()
 

--- a/skylines/model/flight.py
+++ b/skylines/model/flight.py
@@ -521,10 +521,10 @@ class FlightPathChunks(db.Model):
         if len(path_detailed) < 2:
             return False
 
-        # Number of points in each chunck.
+        # Number of points in each chunk.
         num_points = 100
 
-        # Interval of the current chunck: [i, j] (-> path_detailed[i:j + 1])
+        # Interval of the current chunk: [i, j] (-> path_detailed[i:j + 1])
         i = 0
         j = min(num_points - 1, len(path_detailed) - 1)
 


### PR DESCRIPTION
There are small typos in:
- ember/app/sentry.js
- skylines/api/views/flights.py
- skylines/model/flight.py

Fixes:
- Should read `synchronously` rather than `syncronously`.
- Should read `cancellation` rather than `cancelation`.
- Should read `chunk` rather than `chunck`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md