### PR TITLE
docs(livetrack24): fix link to Livetrack24 tracking api

### DIFF
--- a/ember/app/templates/tracking/info.hbs
+++ b/ember/app/templates/tracking/info.hbs
@@ -23,7 +23,7 @@
         </li>
         <li>
           <b>{{t "tracking.lt24-clients"}}:</b><br>
-          {{t "tracking.lt24-description" htmlSafe=true livetrack24=(html-safe "<a href=\"http://www.livetrack24.com/docs/wiki/LiveTracking%20API\">LiveTrack24</a>") skylines=(html-safe "<code>skylines.aero</code>")}}
+          {{t "tracking.lt24-description" htmlSafe=true livetrack24=(html-safe "<a href=\"https://www.livetrack24.com/docs/api\">LiveTrack24</a>") skylines=(html-safe "<code>skylines.aero</code>")}}
         </li>
       </ul>
 

--- a/skylines/frontend/views/livetrack24.py
+++ b/skylines/frontend/views/livetrack24.py
@@ -208,7 +208,7 @@ def track():
     """
     LiveTrack24 tracking API
 
-    see: http://www.livetrack24.com/wiki/LiveTracking%20API
+    see: https://www.livetrack24.com/docs/api
     """
 
     # Read and check the request type
@@ -235,7 +235,7 @@ def client():
     """
     LiveTrack24 tracking API
 
-    see: http://www.livetrack24.com/wiki/LiveTracking%20API
+    see: https://www.livetrack24.com/docs/api
     """
 
     # Read and check the request type


### PR DESCRIPTION
According to their new docs, the current referenced link is for a deprecated API. 